### PR TITLE
web-ext is a required dependency now, for packaging the test extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,14 +21,6 @@ jobs:
     steps:
       # Checkout the code as the first step.
       - checkout
-      - run:
-          name: Configure git for ci-build
-          command: |
-            git config user.email "ci-build@rally-web-platform"
-            git config user.name "ci-build"
-      - run:
-          name: Checkout deploy branch and rebase onto master
-          command: git checkout deploy && git rebase master
       # Next, the node orb's install-packages step will install the dependencies from a package.json.
       # The orb install-packages step will also automatically cache them for faster future runs.
       - node/install-packages
@@ -61,6 +53,14 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run:
+          name: Configure git for ci-build
+          command: |
+            git config user.email "ci-build@rally-web-platform"
+            git config user.name "ci-build"
+      - run:
+          name: Checkout deploy branch and rebase onto master
+          command: git checkout deploy && git rebase master
       - run:
           name: Set up ssh known_hosts # https://circleci.com/docs/2.0/gh-bb-integration/
           command: |

--- a/tests/integration/extension/package.json
+++ b/tests/integration/extension/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@mozilla/rally": "github:mozilla-rally/rally-sdk#b3bb288106f3fe66619fae92c9608e6fca6f5e70",
     "rollup": "^2.56.3",
-    "rollup-plugin-copy": "^3.4.0"
+    "rollup-plugin-copy": "^3.4.0",
+    "web-ext": "^6.4.0"
   }
 }


### PR DESCRIPTION
Packaging of the test extension is failing on merge to main (which makes sense!) but didn't fail in https://github.com/mozilla-rally/rally-web-platform/pull/122 where the change was made. I filed https://github.com/mozilla-rally/rally-web-platform/issues/124 to follow up on that, even if this fixes it.