### PR TITLE
Add cloud functions for sending Glean pings

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,54 +8,174 @@ This means you might have to go searching through the dependency tree to get a f
 
 # Pings
 
-- [rs01-event](#rs01-event)
+- [deletion-request](#deletion-request)
+- [demographics](#demographics)
+- [enrollment](#enrollment)
+- [events](#events)
+- [study-enrollment](#study-enrollment)
+- [study-unenrollment](#study-unenrollment)
+- [unenrollment](#unenrollment)
 
-## rs01-event
+## deletion-request
 
-A ping representing an event sent by the study.
-See the `reasons` documentation for additional
-information.
+This is a built-in ping that is assembled out of the box by the Glean SDK.
 
-**Data reviews for this ping:**
-
-- <https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2>
-
-**Bugs related to this ping:**
-
-- <https://github.com/mozilla-rally/rally-study-01/issues/106>
-
-**Reasons this ping may be sent:**
-
-- `attention`: An attention event is an instance where the user
-  was actively using the browser in an active tab
-  in an active window.
-
-- `audio`: An audio event tells us when an active browser
-  tab has audio playing. We use this as a proxy
-  for a user passively consuming audio and video.
+See the Glean SDK documentation for the [`deletion-request` ping](https://mozilla.github.io/glean/book/user/pings/deletion-request.html).
 
 All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
 
 In addition to those built-in metrics, the following metrics are added to the ping:
 
-| Name                                     | Type                                                                        | Description                                                                                                                                                                                                                                                                                                                                                                           | Data reviews                                                           | Extras                             | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
-| ---------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- | ---------- | -------------------------------------------------------------------- |
-| event.duration                           | [timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) | How long the event occurred.                                                                                                                                                                                                                                                                                                                                                          | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| event.start                              | [datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) | Noting when the event started. If sent in a ping with reason `attention`, this field notes when an inactive tab with a page loaded in it has been given active focus or a new page loads in an already-active tab. If otherwise sent in a ping with reason `audio`, this field notes when an unmuted audio element began playing in the active tab.                                   | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| event.stop                               | [datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) | Noting when the event ended. If sent in a ping with reason `attention`, this field notes when a user closed the active tab, switched or closed the active window, or loaded a new page into the active tab which ends the current attention event. If otherwise sent in a ping with reason `audio`, this field notes when an unmuted audio element stopped playing in the active tab. | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| event.termination_reason                 | [string](https://mozilla.github.io/glean/book/user/metrics/string.html)     | The reason the user’s attention switched to the current attention event (e.g. changed a tab, loaded a new URL in the currently-active tab, closed a tab, closed a window, created a new tab, created a new window, stopped playing audio).                                                                                                                                            | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.attention.max_pixel_scroll_depth    | [quantity](https://mozilla.github.io/glean/book/user/metrics/quantity.html) | The largest scroll pixel depth reached on the page.                                                                                                                                                                                                                                                                                                                                   | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) | <ul><li>unit: pixels</li></ul>     | never      |                                                                      |
-| page.attention.max_relative_scroll_depth | [quantity](https://mozilla.github.io/glean/book/user/metrics/quantity.html) | The largest depth reach on the page, as a proportion of the total page height.                                                                                                                                                                                                                                                                                                        | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) | <ul><li>unit: percentage</li></ul> | never      |                                                                      |
-| page.attention.scroll_height             | [quantity](https://mozilla.github.io/glean/book/user/metrics/quantity.html) | The total scroll height of the page, taken from `document.documentElement.scrollHeight` at the same interval as the other scroll fields.                                                                                                                                                                                                                                              | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) | <ul><li>unit: pixels</li></ul>     | never      |                                                                      |
-| page.id                                  | [string](https://mozilla.github.io/glean/book/user/metrics/string.html)     | A unique ID associated with a page visit. Each page ID is 128-bit value, randomly generated with the Web Crypto API and stored as a hexadecimal string.                                                                                                                                                                                                                               | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.og_description                      | [string](https://mozilla.github.io/glean/book/user/metrics/string.html)     | The `og:description` meta tag contents (e.g. `<meta type="og:description" contents="..." />`). If this isn't supplied, then attempts to look at the meta description contents (e.g. `<meta name="description" content="...">`).                                                                                                                                                       | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.og_type                             | [string](https://mozilla.github.io/glean/book/user/metrics/string.html)     | The `og:type` meta tag contents (e.g. `<meta type="og:type" contents="article" />`).                                                                                                                                                                                                                                                                                                  | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.origin                              | [string](https://mozilla.github.io/glean/book/user/metrics/string.html)     | The origin of the URL associated with the page visit. Calculated by applying `new URL(url).origin`. See the documentation for [url.origin](https://developer.mozilla.org/en-US/docs/Web/API/URL/origin).                                                                                                                                                                              | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.referrer_origin                     | [string](https://mozilla.github.io/glean/book/user/metrics/string.html)     | The origin of the referrer URL for the page loading in the tab.                                                                                                                                                                                                                                                                                                                       | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.title                               | [string](https://mozilla.github.io/glean/book/user/metrics/string.html)     | The contents of the title element in the head of the page.                                                                                                                                                                                                                                                                                                                            | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.visit.start                         | [datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) | When did the page visit start.                                                                                                                                                                                                                                                                                                                                                        | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
-| page.visit.stop                          | [datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) | When did the page visit stop.                                                                                                                                                                                                                                                                                                                                                         | [Bug 1703279](https://bugzilla.mozilla.org/show_bug.cgi?id=1703279#c2) |                                    | never      |                                                                      |
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| rally.id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The id of the Rally client.  |[mozilla-rally/rally-core-addon#505](https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426)||never | |
+
+## demographics
+
+After a user joins the platform they are asked to fill a
+demographic survey, in order to help researchers parse the
+data. The survey is optional and can be partially filled: this
+ping is submitted right after the survey is filled.
+
+
+This ping is sent if empty.
+
+**Data reviews for this ping:**
+
+- <https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232>
+
+**Bugs related to this ping:**
+
+- <https://github.com/mozilla-rally/rally-core-addon/issues/545>
+
+All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
+
+In addition to those built-in metrics, the following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| rally.id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The id of the Rally client.  |[mozilla-rally/rally-core-addon#505](https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426)||never | |
+| user.age |[labeled_boolean](https://mozilla.github.io/glean/book/user/metrics/labeled_booleans.html) |The user age.  |[mozilla-rally/rally-core-addon#139](https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232)|<ul><li>band_19_24</li><li>band_25_34</li><li>band_35_44</li><li>band_45_54</li><li>band_55_64</li><li>band_over_65</li></ul>|never | |
+| user.exact_income |[quantity](https://mozilla.github.io/glean/book/user/metrics/quantity.html) |The user household's combined annual income during the past 12 months. This field replaces the previous income field.  |[mozilla-rally/rally-core-addon#139](https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232), [mozilla-rally/rally-core-addon#624](https://github.com/mozilla-rally/rally-core-addon/pull/624#issuecomment-850479051)|<ul><li>unit: US Dollars</li></ul>|never | |
+| user.gender |[labeled_boolean](https://mozilla.github.io/glean/book/user/metrics/labeled_booleans.html) |The user gender.  |[mozilla-rally/rally-core-addon#139](https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232)|<ul><li>male</li><li>female</li><li>neither</li><li>decline</li></ul>|never | |
+| user.origin |[labeled_boolean](https://mozilla.github.io/glean/book/user/metrics/labeled_booleans.html) |The user origin: Hispanic, Latinx, Spanish or other.  |[mozilla-rally/rally-core-addon#139](https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232)|<ul><li>hispanic_latinx_spanish</li><li>other</li></ul>|never | |
+| user.races |[labeled_boolean](https://mozilla.github.io/glean/book/user/metrics/labeled_booleans.html) |The user race / ethnicity.  |[mozilla-rally/rally-core-addon#139](https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232)|<ul><li>am_indian_or_alaska_native</li><li>asian_indian</li><li>black_or_african_american</li><li>chamorro</li><li>chinese</li><li>filipino</li><li>japanese</li><li>korean</li><li>native_hawaiian</li><li>samoan</li><li>vietnamese</li><li>white</li><li>other_asian</li><li>other_pacific_islander</li><li>some_other_race</li></ul>|never | |
+| user.school |[labeled_boolean](https://mozilla.github.io/glean/book/user/metrics/labeled_booleans.html) |The highest level of school user has completed.  |[mozilla-rally/rally-core-addon#139](https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232)|<ul><li>less_than_high_school</li><li>some_high_school</li><li>high_school_grad_or_eq</li><li>college_degree_in_progress</li><li>associates_degree</li><li>bachelors_degree</li><li>graduate_degree</li></ul>|never | |
+| user.zipcode |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The user zip code.  |[mozilla-rally/rally-core-addon#139](https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232)||never | |
+
+## enrollment
+
+This ping is sent at the end of the user onboarding process,
+when and if the user joins the platform.
+
+
+This ping is sent if empty.
+
+**Data reviews for this ping:**
+
+- <https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5>
+
+**Bugs related to this ping:**
+
+- <https://github.com/mozilla-rally/rally-core-addon/issues/117>
+
+All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
+
+In addition to those built-in metrics, the following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| rally.id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The id of the Rally client.  |[mozilla-rally/rally-core-addon#505](https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426)||never | |
+
+## events
+
+This is a built-in ping that is assembled out of the box by the Glean SDK.
+
+See the Glean SDK documentation for the [`events` ping](https://mozilla.github.io/glean/book/user/pings/events.html).
+
+All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
+
+In addition to those built-in metrics, the following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| rally.id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The id of the Rally client.  |[mozilla-rally/rally-core-addon#505](https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426)||never | |
+
+## study-enrollment
+
+This ping is sent when user clicks the Join button for a study
+and accepts the study policy.
+
+
+This ping is sent if empty.
+
+**Data reviews for this ping:**
+
+- <https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5>
+
+**Bugs related to this ping:**
+
+- <https://github.com/mozilla-rally/rally-core-addon/issues/117>
+
+All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
+
+In addition to those built-in metrics, the following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| enrollment.schema_namespace |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The schema namespace for the study the user has joined.  |[Bug 1663857](https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5)||never | |
+| enrollment.study_id |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The id of the study user has joined.  |[Bug 1663857](https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5)||never | |
+| rally.id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The id of the Rally client.  |[mozilla-rally/rally-core-addon#505](https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426)||never | |
+
+## study-unenrollment
+
+This ping is sent when user leaves a study.
+
+
+This ping is sent if empty.
+
+**Data reviews for this ping:**
+
+- <https://bugzilla.mozilla.org/show_bug.cgi?id=1646151#c32>
+
+**Bugs related to this ping:**
+
+- <https://github.com/mozilla-rally/rally-core-addon/issues/545>
+
+All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
+
+In addition to those built-in metrics, the following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| rally.id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The id of the Rally client.  |[mozilla-rally/rally-core-addon#505](https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426)||never | |
+| unenrollment.schema_namespace |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The schema namespace for the study the user has left.  |[Bug 1646151](https://bugzilla.mozilla.org/show_bug.cgi?id=1646151#c32)||never | |
+| unenrollment.study_id |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The id of the study user has left.  |[Bug 1646151](https://bugzilla.mozilla.org/show_bug.cgi?id=1646151#c32)||never | |
+
+## unenrollment
+
+This ping is sent when and if the user chooses to leave the platform.
+
+
+This ping is sent if empty.
+
+**Data reviews for this ping:**
+
+- <https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5>
+
+**Bugs related to this ping:**
+
+- <https://github.com/mozilla-rally/rally-core-addon/issues/117>
+
+All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
+
+In addition to those built-in metrics, the following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| rally.id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |The id of the Rally client.  |[mozilla-rally/rally-core-addon#505](https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426)||never | |
 
 Data categories are [defined here](https://wiki.mozilla.org/Firefox/Data_Collection).
 
 <!-- AUTOGENERATED BY glean_parser. DO NOT EDIT. -->
+

--- a/functions/.testenv
+++ b/functions/.testenv
@@ -1,2 +1,3 @@
 GCLOUD_PROJECT="demo-rally"
 FIRESTORE_EMULATOR_HOST="localhost:8080"
+NODE_OPTIONS=--experimental-vm-modules

--- a/functions/jest.config.js
+++ b/functions/jest.config.js
@@ -1,5 +1,15 @@
-module.exports = {
-  preset: "ts-jest",
+export default {
+  preset: "ts-jest/presets/default-esm",
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  resolver: "ts-jest-resolver",
+  moduleNameMapper: {
+    "^@mozilla/glean/plugins/encryption": "@mozilla/glean/dist/plugins/encryption.js",
+    "^@mozilla/glean/uploader": "@mozilla/glean/dist/core/upload/uploader.js"
+  },
   testRegex: "src(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   testPathIgnorePatterns: ["lib/", "node_modules/", "setupTests.js"],
   moduleFileExtensions: ["js", "ts", "tsx", "jsx", "json", "node"],

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4,8 +4,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "functions",
       "dependencies": {
+        "@mozilla/glean": "^1.0.0",
         "cors": "^2.8.5",
         "firebase-admin": "^9.8.0",
         "firebase-functions": "^3.15.5"
@@ -1574,6 +1574,32 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@mozilla/glean": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.0.0.tgz",
+      "integrity": "sha512-2RzkubrxaCV7mkmCXgBmD16XbDuK4SVqlMdLv3zez2lb3WXnLo6j+C+IKIgBke/f/iGgz6O4SISjTAhkaPvgNQ==",
+      "dependencies": {
+        "fflate": "^0.7.1",
+        "jose": "^4.0.4",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "bin": {
+        "glean": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=12.20.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@mozilla/glean/node_modules/jose": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
+      "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@panva/asn1.js": {
@@ -3743,6 +3769,11 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7842,7 +7873,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "devOptional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -9379,6 +9409,24 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@mozilla/glean": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.0.0.tgz",
+      "integrity": "sha512-2RzkubrxaCV7mkmCXgBmD16XbDuK4SVqlMdLv3zez2lb3WXnLo6j+C+IKIgBke/f/iGgz6O4SISjTAhkaPvgNQ==",
+      "requires": {
+        "fflate": "^0.7.1",
+        "jose": "^4.0.4",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "jose": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
+          "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w=="
+        }
       }
     },
     "@panva/asn1.js": {
@@ -11106,6 +11154,11 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fflate": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
+      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -14269,8 +14322,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "devOptional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "functions",
       "dependencies": {
         "@mozilla/glean": "^1.0.0",
         "cors": "^2.8.5",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,6 +7,7 @@
       "name": "functions",
       "dependencies": {
         "@mozilla/glean": "^1.0.0",
+        "axios": "^0.26.1",
         "cors": "^2.8.5",
         "firebase-admin": "^9.8.0",
         "firebase-functions": "^3.15.5"
@@ -22,7 +23,7 @@
         "eslint-plugin-import": "^2.22.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.3",
-        "typescript": "^3.8.0",
+        "typescript": "^4.7.0-dev.20220404",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -1955,6 +1956,41 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
@@ -2045,6 +2081,41 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -2316,6 +2387,14 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
     },
     "node_modules/babel-jest": {
       "version": "27.5.1",
@@ -3899,6 +3978,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -7715,27 +7813,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7791,9 +7868,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.7.0-dev.20220404",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.0-dev.20220404.tgz",
+      "integrity": "sha512-mwDmc7qyaMDaspyaXZLK5W82M8fmvMf+4Eo0jWJBKcLNSPqQl/K50jr0/Of1LETKVoYZEB/G80aBI/MRyHBwaw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -9758,6 +9835,30 @@
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "typescript": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+          "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -9806,6 +9907,30 @@
         "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "typescript": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+          "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@typescript-eslint/visitor-keys": {
@@ -10003,6 +10128,14 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -11260,6 +11393,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -14206,23 +14344,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
-    "tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
-      }
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -14263,9 +14384,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.7.0-dev.20220404",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.0-dev.20220404.tgz",
+      "integrity": "sha512-mwDmc7qyaMDaspyaXZLK5W82M8fmvMf+4Eo0jWJBKcLNSPqQl/K50jr0/Of1LETKVoYZEB/G80aBI/MRyHBwaw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "functions",
+  "type": "module",
   "scripts": {
     "lint": "eslint --ext .js,.ts .",
     "build": "npm run build:glean && tsc",
@@ -21,6 +22,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@mozilla/glean": "^1.0.0",
+    "axios": "^0.26.1",
     "cors": "^2.8.5",
     "firebase-admin": "^9.8.0",
     "firebase-functions": "^3.15.5"
@@ -36,7 +38,7 @@
     "eslint-plugin-import": "^2.22.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
-    "typescript": "^3.8.0",
+    "typescript": "^4.7.0-dev.20220404",
     "uuid": "^8.3.2"
   },
   "private": true

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,8 @@
     "axios": "^0.26.1",
     "cors": "^2.8.5",
     "firebase-admin": "^9.8.0",
-    "firebase-functions": "^3.15.5"
+    "firebase-functions": "^3.15.5",
+    "ts-jest-resolver": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
@@ -38,7 +39,7 @@
     "eslint-plugin-import": "^2.22.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
-    "typescript": "^4.7.0-dev.20220404",
+    "typescript": "^4.6.3",
     "uuid": "^8.3.2"
   },
   "private": true

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,11 +2,14 @@
   "name": "functions",
   "scripts": {
     "lint": "eslint --ext .js,.ts .",
-    "build": "tsc",
+    "build": "npm run build:glean && tsc",
+    "build:glean": "glean translate ../metrics.yaml ../pings.yaml -f typescript -o ./src/generated",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
+    "docs:glean": "glean translate ../metrics.yaml ../pings.yaml -f markdown -o ../docs",
+    "lint:glean": "glean glinter ../metrics.yaml ../pings.yaml",
     "logs": "firebase functions:log",
     "test": "set -a && . ./.testenv && jest --coverage --detectOpenHandles && set +a",
     "test:coverage": "set -a && . ./.testenv && jest --coverage --collectCoverage --coverageDirectory coverage --detectOpenHandles && set +a",
@@ -17,6 +20,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "@mozilla/glean": "^1.0.0",
     "cors": "^2.8.5",
     "firebase-admin": "^9.8.0",
     "firebase-functions": "^3.15.5"

--- a/functions/src/__tests__/authentication.test.ts
+++ b/functions/src/__tests__/authentication.test.ts
@@ -1,8 +1,10 @@
+import { jest } from "@jest/globals";
+
 jest.mock("firebase-admin");
 
-import * as admin from "firebase-admin";
-import * as functions from "firebase-functions";
-import { AuthenticatedFunction, useAuthentication } from "../authentication";
+import admin from "firebase-admin";
+import functions from "firebase-functions";
+import { AuthenticatedFunction, useAuthentication } from "../authentication.js";
 
 describe("useAuthentication", () => {
   const request = {
@@ -34,7 +36,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws when request is null", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await expect(() =>
       useAuthentication(
@@ -48,7 +50,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws when request is undefined", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await expect(() =>
       useAuthentication(
@@ -62,7 +64,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws when response is null", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await expect(() =>
       useAuthentication(
@@ -76,7 +78,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws when response is undefined", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await expect(() =>
       useAuthentication(
@@ -120,7 +122,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws http error 401 when request is missing", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await useAuthentication(
       ({} as unknown) as functions.https.Request,
@@ -134,7 +136,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws http error 401 when request authorization header is missing", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await useAuthentication(
       { ...request, headers: {} } as functions.https.Request,
@@ -148,7 +150,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws http error 401 when bearer prefix is missing", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await useAuthentication(
       {
@@ -165,7 +167,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws http error 401 when bearer prefix is not pascal cased", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await useAuthentication(
       {
@@ -182,7 +184,7 @@ describe("useAuthentication", () => {
   });
 
   it("throws http error 401 when auth header has more than 2 parts", async () => {
-    const fn = jest.fn();
+    const fn: any = jest.fn();
 
     await useAuthentication(
       {
@@ -201,7 +203,7 @@ describe("useAuthentication", () => {
   it("throws http error 401 when token is invalid", async () => {
     fakeAuth.verifyIdToken.mockRejectedValue("Invalid token");
 
-    const fn = jest.fn();
+    const fn: any = jest.fn();
     await useAuthentication(request, response, fn);
 
     expect(response.status).toHaveBeenCalledWith(401);
@@ -215,9 +217,9 @@ describe("useAuthentication", () => {
       uid: "abc123",
     } as admin.auth.DecodedIdToken;
 
-    fakeAuth.verifyIdToken.mockResolvedValue(decryptedToken);
+    fakeAuth.verifyIdToken.mockReturnValue(decryptedToken);
 
-    const innerFn = jest.fn();
+    const innerFn: any = jest.fn();
     await useAuthentication(request, response, innerFn);
 
     expect(innerFn).toHaveBeenCalledWith(decryptedToken);

--- a/functions/src/__tests__/index.test.ts
+++ b/functions/src/__tests__/index.test.ts
@@ -1,15 +1,14 @@
-jest.mock("../cors");
+import { jest } from "@jest/globals";
 
-import * as admin from "firebase-admin";
-import { useCors } from "../cors";
-import * as functions from "firebase-functions";
+import admin from "firebase-admin";
+import functions from "firebase-functions";
 import {
   addRallyUserToFirestoreImpl,
   deleteRallyUserImpl,
   loadFirestore,
   rallytoken,
-} from "../index";
-import { studies } from "../studies";
+} from "../index.js";
+import { studies } from "../studies.js";
 
 describe("loadFirestore", () => {
   const studyName = Object.keys(studies)[0];
@@ -141,7 +140,7 @@ describe("addRallyUserToFirestore and deleteRallyUserImpl", () => {
 });
 
 describe("rallytoken tests", () => {
-  let send: jest.Mock<any, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  let send: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   let response: functions.Response<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
   const uid = "fake-uid";
@@ -161,6 +160,13 @@ describe("rallytoken tests", () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
+    jest.mock("../cors.js", () => {
+      return {
+        __esModule: true,
+        useCors: jest.fn(async (req, res, fn: any) => await fn(req, res)),
+      };
+    });
+
     send = jest.fn();
     response = ({
       set: jest.fn(),
@@ -169,10 +175,6 @@ describe("rallytoken tests", () => {
 
     fakeAuth.verifyIdToken.mockReturnValue({ uid });
     fakeAuth.createCustomToken.mockReturnValue(customToken);
-
-    (useCors as jest.Mock).mockImplementation(
-      async (req, res, fn) => await fn(req, res)
-    );
   });
 
   afterEach(() => {

--- a/functions/src/__tests__/index.test.ts
+++ b/functions/src/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import * as admin from "firebase-admin";
 import { useCors } from "../cors";
 import * as functions from "firebase-functions";
 import {
-  addRallyStudyToFirestoreImpl,
+  addRallyUserToFirestoreImpl,
   deleteRallyUserImpl,
   loadFirestore,
   rallytoken,
@@ -82,7 +82,7 @@ describe("addRallyUserToFirestore and deleteRallyUserImpl", () => {
 
   it("empty provider data does not register extension users", async () => {
     await expect(
-      addRallyStudyToFirestoreImpl({ ...user, providerData: [] })
+      addRallyUserToFirestoreImpl({ ...user, providerData: [] })
     ).resolves.toBeFalsy();
 
     const userRecords = await getUserRecords();
@@ -93,7 +93,7 @@ describe("addRallyUserToFirestore and deleteRallyUserImpl", () => {
 
   async function createAndValidateUserRecords() {
     await expect(
-      addRallyStudyToFirestoreImpl({
+      addRallyUserToFirestoreImpl({
         ...user,
         providerData: [{ uid: user.uid } as admin.auth.UserInfo],
       })

--- a/functions/src/authentication.ts
+++ b/functions/src/authentication.ts
@@ -1,6 +1,6 @@
-import * as assert from "assert";
-import * as admin from "firebase-admin";
-import * as functions from "firebase-functions";
+import assert from "assert";
+import admin from "firebase-admin";
+import functions from "firebase-functions";
 
 export type AuthenticatedFunction = (
   decodedToken: admin.auth.DecodedIdToken

--- a/functions/src/cors.ts
+++ b/functions/src/cors.ts
@@ -1,4 +1,4 @@
-import * as cors from "cors";
+import cors from "cors";
 
 export const useCors = cors({
   origin: true,

--- a/functions/src/glean.ts
+++ b/functions/src/glean.ts
@@ -1,0 +1,276 @@
+import PingEncryptionPlugin from "@mozilla/glean/plugins/encryption";
+import axios from "axios";
+import { Worker, workerData, isMainThread } from "worker_threads";
+
+import { fileURLToPath } from "url";
+const __filename = fileURLToPath(import.meta.url);
+
+import {
+  Uploader,
+  UploadResult,
+  UploadResultStatus,
+} from "@mozilla/glean/uploader";
+
+const GLEAN_DEBUG_VIEW_TAG = "MozillaRally";
+const GLEAN_RALLY_APP_ID = "my-app-id";
+const GLEAN_APP_DISPLAY_VERSION = "TODO-rally-firestore-server";
+const GLEAN_ENCRYPTION_JWK = {
+  crv: "P-256",
+  kid: "rally-core",
+  kty: "EC",
+  x: "m7Gi2YD8DgPg3zxora5iwf0DFL0JFIhjoD2BRLpg7kI",
+  y: "zo35XIQME7Ct01uHK_LrMi5pZCuYDMhv8MUsSu7Eq08",
+};
+
+// Worker thread for handling ping
+// This is only run when spawnPingThread creates a new worker
+async function main() {
+  if (!isMainThread) {
+    const { taskName, rallyID, studyID, demographicsData } = workerData;
+    switch (taskName) {
+      case "platformEnrollment":
+        await platformEnrollmentImpl(rallyID);
+        break;
+      case "platformUnenrollment":
+        await platformUnenrollmentImpl(rallyID);
+        break;
+      case "studyEnrollment":
+        await studyEnrollmentImpl(rallyID, studyID);
+        break;
+      case "studyUnenrollment":
+        await studyUnenrollmentImpl(rallyID, studyID);
+        break;
+      case "demographics":
+        await demographicsImpl(rallyID, demographicsData);
+        break;
+      default:
+        throw new Error(`unknown taskName ${taskName} passed to workerThread`);
+    }
+    process.exit();
+  }
+}
+main();
+
+async function spawnPingThread(params: any) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(__filename, {
+      workerData: params,
+    });
+    worker.on("error", reject);
+    worker.on("exit", (code) => {
+      if (code !== 0) reject(new Error(`stopped with ${code} exit code`));
+      resolve(code);
+    });
+  });
+}
+
+/*
+ * platformEnrollment
+ * Glean ping: enrollment
+ */
+export async function platformEnrollment(rallyID: string) {
+  await spawnPingThread({ taskName: "platformEnrollment", rallyID: rallyID });
+}
+
+async function platformEnrollmentImpl(rallyID: string) {
+  const { default: Glean } = await import("@mozilla/glean/node");
+  const rallyPings = await initializeGlean(Glean, GLEAN_RALLY_APP_ID, rallyID);
+
+  rallyPings.enrollment.submit();
+
+  await Glean.shutdown();
+}
+
+/*
+ * platformUnenrollment
+ * Glean ping: unenrollment, deletion-request
+ *
+ */
+export async function platformUnenrollment(rallyID: string) {
+  await spawnPingThread({ taskName: "platformUnenrollment", rallyID: rallyID });
+}
+
+async function platformUnenrollmentImpl(rallyID: string) {
+  const { default: Glean } = await import("@mozilla/glean/node");
+  const rallyPings = await initializeGlean(Glean, GLEAN_RALLY_APP_ID, rallyID);
+
+  rallyPings.unenrollment.submit();
+  Glean.setUploadEnabled(false); // automatically trigger a deletion-request ping
+
+  await Glean.shutdown();
+}
+
+/*
+ * demographics
+ * Glean ping: demographics
+ */
+export async function demographics(rallyID: string, demographicsData: any) {
+  await spawnPingThread({
+    taskName: "demographics",
+    rallyID: rallyID,
+    demographicsData: demographicsData,
+  });
+}
+
+async function demographicsImpl(rallyID: string, demographicsData: any) {
+  const { default: Glean } = await import("@mozilla/glean/node");
+  const rallyPings = await initializeGlean(Glean, GLEAN_RALLY_APP_ID, rallyID);
+
+  const userMetrics = await import("./generated/user.js");
+  setUserMetrics(userMetrics, demographicsData);
+  rallyPings.demographics.submit();
+
+  await Glean.shutdown();
+}
+
+/*
+ * studyEnrollment
+ * Glean ping: study-enrollment
+ */
+export async function studyEnrollment(rallyID: string, studyID: string) {
+  await spawnPingThread({
+    taskName: "studyEnrollment",
+    rallyID: rallyID,
+    studyID: studyID,
+  });
+}
+
+async function studyEnrollmentImpl(rallyID: string, studyID: string) {
+  const { default: Glean } = await import("@mozilla/glean/node");
+  const rallyPings = await initializeGlean(Glean, studyID, rallyID); // study ID is app ID
+
+  const enrollmentMetrics = await import("./generated/enrollment.js");
+  enrollmentMetrics.studyId.set(studyID);
+  rallyPings.studyEnrollment.submit();
+
+  await Glean.shutdown();
+}
+
+/*
+ * studyUnenrollment
+ * Glean ping: study-unenrollment, deletion-request
+ */
+export async function studyUnenrollment(rallyID: string, studyID: string) {
+  await spawnPingThread({
+    taskName: "studyUnenrollment",
+    rallyID: rallyID,
+    studyID: studyID,
+  });
+}
+
+async function studyUnenrollmentImpl(rallyID: string, studyID: string) {
+  const { default: Glean } = await import("@mozilla/glean/node");
+  const rallyPings = await initializeGlean(Glean, studyID, rallyID); // study ID is app ID
+
+  const unenrollmentMetrics = await import("./generated/unenrollment.js");
+  unenrollmentMetrics.studyId.set(studyID);
+  rallyPings.studyUnenrollment.submit();
+
+  Glean.setUploadEnabled(false); // automatically trigger a deletion-request ping
+  await Glean.shutdown();
+}
+
+/*
+ * Helper function for initializing Glean
+ */
+async function initializeGlean(
+  Glean: any,
+  appID: string,
+  rallyID: string,
+  uploadEnabled: boolean = true
+) {
+  Glean.setDebugViewTag(GLEAN_DEBUG_VIEW_TAG);
+  Glean.setLogPings(true);
+  Glean.initialize(appID, true, {
+    appDisplayVersion: GLEAN_APP_DISPLAY_VERSION,
+    plugins: [new PingEncryptionPlugin(GLEAN_ENCRYPTION_JWK)],
+    httpClient: new CustomPingUploader(),
+  });
+
+  Glean.setUploadEnabled(uploadEnabled);
+  const rallyMetrics = await import("./generated/rally.js");
+  rallyMetrics.id.set(rallyID);
+  const rallyPings = await import("./generated/pings.js");
+  return rallyPings; // Always need rallyPings, so return it to initializer
+}
+
+/*
+ * Helper function for setting user metrics
+ * from demographic data (mapping)
+ */
+function setUserMetrics(userMetrics: any, data: any) {
+  if ("age" in data) {
+    userMetrics.age[`band_${data["age"]}`].set(true);
+  }
+
+  if ("gender" in data) {
+    userMetrics.gender[data["gender"]].set(true);
+  }
+
+  if ("hispanicLatinxSpanishOrigin" in data) {
+    const label =
+      data["hispanicLatinxSpanishOrigin"] === "other"
+        ? "other"
+        : "hispanic_latinx_spanish";
+    userMetrics.origin[label].set(true);
+  }
+
+  if ("race" in data) {
+    for (const raceLabel of data["race"]) {
+      const label =
+        raceLabel === "american_indian_or_alaska_native"
+          ? "am_indian_or_alaska_native"
+          : raceLabel;
+      userMetrics.races[label].set(true);
+    }
+  }
+
+  if ("school" in data) {
+    const KEY_FIXUP: any = {
+      high_school_graduate_or_equivalent: "high_school_grad_or_eq",
+      some_college_but_no_degree_or_in_progress: "college_degree_in_progress",
+    };
+
+    const originalLabel = data["school"];
+    const label =
+      originalLabel in KEY_FIXUP ? KEY_FIXUP[originalLabel] : originalLabel;
+    userMetrics.school[label].set(true);
+  }
+
+  if ("exactIncome" in data) {
+    userMetrics.exactIncome.set(data["exactIncome"]);
+  }
+
+  if ("zipcode" in data) {
+    userMetrics.zipcode.set(data["zipcode"]);
+  }
+}
+
+/**
+ * Custom Ping Uploader for Glean
+ * TODO: replace direct POST request with Google Cloud Task
+ */
+class CustomPingUploader extends Uploader {
+  async post(
+    url: string,
+    body: string | Uint8Array,
+    headers: any
+  ): Promise<UploadResult> {
+    return await axios
+      .post(url, body, { headers: headers })
+      .then(function (response) {
+        // console.log(response);
+        return {
+          status: response.status,
+          result: UploadResultStatus.Success,
+        };
+      })
+      .catch(function (error) {
+        console.log(error);
+        return {
+          status: 500,
+          result: UploadResultStatus.UnrecoverableFailure,
+        };
+      });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -234,9 +234,9 @@ export const handleUserChangesImpl = async function (
   return true;
 };
 
-export const handleUserChanges = functions.firestore
-  .document("users/{userID}")
-  .onWrite(handleUserChangesImpl);
+// export const handleUserChanges = functions.firestore
+//   .document("users/{userID}")
+//   .onWrite(handleUserChangesImpl);
 
 /*
  * Listen for changes to the Study document
@@ -299,9 +299,9 @@ export const handleUserStudyChangesImpl = async function (
   return true;
 };
 
-export const handleUserStudyChanges = functions.firestore
-  .document("users/{userID}/studies/{studyID}")
-  .onWrite(handleUserStudyChangesImpl);
+// export const handleUserStudyChanges = functions.firestore
+//   .document("users/{userID}/studies/{studyID}")
+//   .onWrite(handleUserStudyChangesImpl);
 
 async function getRallyIdForUser(userID: string) {
   let extensionUserDoc = await admin

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,14 +1,18 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017",
+    "allowJs": true,
+    "checkJs": true,
+    "target": "es2019",
     "typeRoots": ["node_modules/@types"]
   },
   "compileOnSave": true,
-  "include": ["src"]
+  "include": ["src"],
 }

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -1,0 +1,247 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK.
+# APIs to use these pings are automatically generated at build time using
+# the `glean_parser` PyPI package.
+
+# Metrics in this file may make use of SDK reserved ping names. See
+# https://mozilla.github.io/glean/book/dev/core/internal/reserved-ping-names.html
+# for additional information.
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+rally:
+  id:
+    type: uuid
+    lifetime: user
+    send_in_pings:
+      - deletion-request
+      - enrollment
+      - unenrollment
+      - study-enrollment
+      - study-unenrollment
+      - demographics
+      - events
+    description: |
+      The id of the Rally client.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/117
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/505#issuecomment-815826426
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+enrollment:
+  study_id:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - study-enrollment
+    description: |
+      The id of the study user has joined.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  schema_namespace:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - study-enrollment
+    description: |
+      The schema namespace for the study the user has joined.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+unenrollment:
+  study_id:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - study-unenrollment
+    description: |
+      The id of the study user has left.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1646151#c32
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  schema_namespace:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - study-unenrollment
+    description: |
+      The schema namespace for the study the user has left.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1646151#c32
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+user:
+  age:
+    type: labeled_boolean
+    lifetime: ping
+    send_in_pings:
+      - demographics
+    labels:
+      - band_19_24
+      - band_25_34
+      - band_35_44
+      - band_45_54
+      - band_55_64
+      - band_over_65
+    description: |
+      The user age.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  gender:
+    type: labeled_boolean
+    lifetime: ping
+    send_in_pings:
+      - demographics
+    labels:
+      - male
+      - female
+      - neither
+      - decline
+    description: |
+      The user gender.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  origin:
+    type: labeled_boolean
+    lifetime: ping
+    send_in_pings:
+      - demographics
+    labels:
+      - hispanic_latinx_spanish
+      - other
+    description: |
+      The user origin: Hispanic, Latinx, Spanish or other.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  races:
+    type: labeled_boolean
+    lifetime: ping
+    send_in_pings:
+      - demographics
+    labels:
+      - am_indian_or_alaska_native
+      - asian_indian
+      - black_or_african_american
+      - chamorro
+      - chinese
+      - filipino
+      - japanese
+      - korean
+      - native_hawaiian
+      - samoan
+      - vietnamese
+      - white
+      - other_asian
+      - other_pacific_islander
+      - some_other_race
+    description: |
+      The user race / ethnicity.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  school:
+    type: labeled_boolean
+    lifetime: ping
+    send_in_pings:
+      - demographics
+    labels:
+      - less_than_high_school
+      - some_high_school
+      - high_school_grad_or_eq
+      - college_degree_in_progress
+      - associates_degree
+      - bachelors_degree
+      - graduate_degree
+    description: |
+      The highest level of school user has completed.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  exact_income:
+    type: quantity
+    lifetime: ping
+    unit: US Dollars
+    send_in_pings:
+      - demographics
+    description: |
+      The user household's combined annual income during the
+      past 12 months. This field replaces the previous income field.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+      - https://github.com/mozilla-rally/rally-core-addon/issues/621
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+      - https://github.com/mozilla-rally/rally-core-addon/pull/624#issuecomment-850479051
+    notification_emails:
+      - than@mozilla.com
+    expires: never
+
+  zipcode:
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - demographics
+    description: |
+      The user zip code.
+    bugs:
+      - https://github.com/mozilla-rally/rally-core-addon/issues/545
+    data_reviews:
+      - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+    notification_emails:
+      - than@mozilla.com
+    expires: never

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run pre-build && npm run build:functions && svelte-kit build && npm run compile:sass",
     "build:functions": "cd functions && npm install && npm run build && cd ..",
     "build:web:emulator": "npm run pre-build && npm run config:web:demo && svelte-kit build -- --config-emulator-mode",
-    "watch:functions": "watch 'npm run build:functions && sleep 1 && npm run load:data' ./functions/src > /dev/null",
+    "watch:functions": "watch 'npm run build:functions && sleep 1 && npm run load:data' ./functions/src --ignoreDirectoryPattern='/generated/g' > /dev/null",
     "watch:web": "svelte-kit dev -- --config-emulator-mode",
     "load:data": "curl -s http://localhost:5001/demo-rally/us-central1/loadFirestore",
     "preview": "svelte-kit preview",

--- a/pings.yaml
+++ b/pings.yaml
@@ -1,0 +1,75 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the pings that are recorded by the Glean SDK.
+# Their code APIs is automatically generated, at build time using,
+# the `glean_parser` PyPI package.
+
+---
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+enrollment:
+  description: |
+    This ping is sent at the end of the user onboarding process,
+    when and if the user joins the platform.
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - https://github.com/mozilla-rally/rally-core-addon/issues/117
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5
+  notification_emails:
+    - than@mozilla.com
+
+unenrollment:
+  description: |
+    This ping is sent when and if the user chooses to leave the platform.
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - https://github.com/mozilla-rally/rally-core-addon/issues/117
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5
+  notification_emails:
+    - than@mozilla.com
+
+study-enrollment:
+  description: |
+    This ping is sent when user clicks the Join button for a study
+    and accepts the study policy.
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - https://github.com/mozilla-rally/rally-core-addon/issues/117
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1663857#c5
+  notification_emails:
+    - than@mozilla.com
+
+study-unenrollment:
+  description: |
+    This ping is sent when user leaves a study.
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - https://github.com/mozilla-rally/rally-core-addon/issues/545
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1646151#c32
+  notification_emails:
+    - than@mozilla.com
+
+demographics:
+  description: |
+    After a user joins the platform they are asked to fill a
+    demographic survey, in order to help researchers parse the
+    data. The survey is optional and can be partially filled: this
+    ping is submitted right after the survey is filled.
+  include_client_id: false
+  send_if_empty: true
+  bugs:
+    - https://github.com/mozilla-rally/rally-core-addon/issues/545
+  data_reviews:
+    - https://github.com/mozilla-rally/rally-core-addon/pull/139#issuecomment-736024232
+  notification_emails:
+    - than@mozilla.com


### PR DESCRIPTION
For issue #108 

- Glean yamls + docs
- build process for generating Glean code
- helper function for getting a user's rallyID
- renamed `addRallyStudyToFirestoreImpl()` to `addRallyUserToFirestoreImpl()` (function was misnamed)

- Port functions from using commonJS to use ES Modules
- cloud functions triggered on appropriate document changes
    - Glean pings dispatched on appropriate field changes
- each Glean ping dispatched in dedicated workerThread

NB: testing for functions is broken due to port from cjs to es modules, and need to be fixed or rewritten.
In the mean time, Glean pings are logged locally, and also appear [here](https://debug-ping-preview.firebaseapp.com/pings/MozillaRally) once successfully submitted.