### PR TITLE
Enable Firebase analytics

### DIFF
--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -314,6 +314,7 @@ export default {
     }
     // create a new user.
     if (userCredential) {
+      // @ts-ignore
       console.debug("Logged in as", userCredential.user.email);
       initializeUserDocument(userCredential.user.uid);
       listenForUserChanges(userCredential.user);

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -93,7 +93,7 @@ const _authChangeCallbacks = [async (/** @type {import("firebase/auth").User} */
   logEvent = (await import("firebase/analytics")).logEvent
 
   const loggedIn = Boolean(user && user.uid);
-  logEvent(analytics, `sign-${loggedIn ? "in" : "out"}`);
+  logEvent(analytics, `sign_${loggedIn ? "in" : "out"}`);
 }];
 
 function _updateLocalState(callback) {

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -85,6 +85,7 @@ const _stateChangeCallbacks = [];
 const _connectedChangeCallbacks = [async (studyId) => {
   analytics = (await import("firebase/analytics")).getAnalytics();
   logEvent = (await import("firebase/analytics")).logEvent
+
   logEvent(analytics, "activate_extension", { studyId });
 }];
 

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -89,7 +89,6 @@ const _connectedChangeCallbacks = [async (studyId) => {
 }];
 
 const _authChangeCallbacks = [async (/** @type {import("firebase/auth").User} */ user) => {
-  console.debug(`auth state change callback: ${JSON.stringify(user)}`);
   analytics = (await import("firebase/analytics")).getAnalytics();
   logEvent = (await import("firebase/analytics")).logEvent
 

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -314,7 +314,6 @@ export default {
     }
     // create a new user.
     if (userCredential) {
-      // @ts-ignore
       console.debug("Logged in as", userCredential.user.email);
       initializeUserDocument(userCredential.user.uid);
       listenForUserChanges(userCredential.user);

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -306,6 +306,7 @@ export default {
     // Allow user to select which Google account to use.
     provider.setCustomParameters({ prompt: "select_account" });
 
+    /** @type {import("firebase/auth").UserCredential} */
     let userCredential;
     try {
       userCredential = await signInWithRedirect(auth, provider);
@@ -314,7 +315,6 @@ export default {
     }
     // create a new user.
     if (userCredential) {
-      // @ts-ignore
       console.debug("Logged in as", userCredential.user.email);
       initializeUserDocument(userCredential.user.uid);
       listenForUserChanges(userCredential.user);

--- a/src/lib/views/studies/StudyCardContainer.svelte
+++ b/src/lib/views/studies/StudyCardContainer.svelte
@@ -52,9 +52,14 @@
   }
 
   let Dialog;
+  let analytics;
+  let logEvent;
   let mounted = false;
   onMount(async () => {
     Dialog = (await import("$lib/components/Dialog.svelte")).default;
+    analytics = (await import("firebase/analytics")).getAnalytics();
+    logEvent = (await import("firebase/analytics")).logEvent;
+
     mounted = true;
   });
 </script>
@@ -211,12 +216,30 @@
         leave={joined}
         custom={joined ? "outline" : ""}
         on:click={() => {
+          logEvent(analytics, "select_content", {
+            content_type: `${joined ? "leave" : "join"}_study`,
+          });
           // send join event to parent.
           dispatch(!joined ? "join" : "leave");
           joinModal = false;
         }}
       >
         {#if joined}Leave Study{:else}Add study extension{/if}
+      </Button>
+      <Button
+        size="lg"
+        product
+        secondary  
+        on:click={() => {
+          console.debug("logEvent:", logEvent);
+          logEvent(analytics, "select_content", {
+            content_type: `canceled_${joined ? "join" : "leave"}_study`,
+          });
+
+          joinModal = false;
+        }}
+      >
+        Cancel
       </Button>
     </div>
   </Dialog>

--- a/src/lib/views/studies/StudyCardContainer.svelte
+++ b/src/lib/views/studies/StudyCardContainer.svelte
@@ -229,20 +229,6 @@
       >
         {#if joined}Leave Study{:else}Add study extension{/if}
       </Button>
-      <Button
-        size="lg"
-        product
-        secondary  
-        on:click={() => {
-          logEvent(analytics, "select_content", {
-            content_type: `canceled_${joined ? "join" : "leave"}_study`,
-          });
-
-          joinModal = false;
-        }}
-      >
-        Cancel
-      </Button>
     </div>
   </Dialog>
 {/if}

--- a/src/lib/views/studies/StudyCardContainer.svelte
+++ b/src/lib/views/studies/StudyCardContainer.svelte
@@ -204,6 +204,9 @@
         neutral
         secondary
         on:click={() => {
+          logEvent(analytics, "select_content", {
+            content_type: `canceled_${joined ? "leave" : "join"}_study`,
+          });
           joinModal = false;
         }}
       >

--- a/src/lib/views/studies/StudyCardContainer.svelte
+++ b/src/lib/views/studies/StudyCardContainer.svelte
@@ -231,7 +231,6 @@
         product
         secondary  
         on:click={() => {
-          console.debug("logEvent:", logEvent);
           logEvent(analytics, "select_content", {
             content_type: `canceled_${joined ? "join" : "leave"}_study`,
           });

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -144,7 +144,7 @@ describe("Rally Web Platform UX flows", function () {
       e.click()
     );
 
-    await driver.wait(
+      await driver.wait(
       until.titleIs("Studies | Mozilla Rally"),
       WAIT_FOR_PROPERTY
     );

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -144,7 +144,7 @@ describe("Rally Web Platform UX flows", function () {
       e.click()
     );
 
-      await driver.wait(
+    await driver.wait(
       until.titleIs("Studies | Mozilla Rally"),
       WAIT_FOR_PROPERTY
     );


### PR DESCRIPTION
This imports and sets up the Firebase analytics library from the Firebase SDK, which requires a browser `window` (so it won't work in SSR mode, needs to run `onMount` in svelte).

The standard [select_content](https://developers.google.com/analytics/devguides/collection/ga4/reference/events#select_content) is used to track join/leave study, and sends a few custom events:

- `sign_in` / `sign_out` when the auth state callback is called with non-null user
- `activate_extension` when the website receives a message that the extension has logged

We should prefer to use standard events wherever possible, happy to change these as we find good matches, but I wanted to give a more complete example of how this works.

It depends on the stage and prod instances having FA enabled in https://mozilla-hub.atlassian.net/browse/DSRE-747