### PR TITLE
This is a followup PR that fixes minor UI gaps that were identified in https://github.com/mozilla-rally/rally-web-platform/pull/337

### DIFF
--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -19,6 +19,7 @@
   export let minHeight;
   export let fontSize = "38px";
   export let custom = "";
+  export let showCloseButton = true;
 
   function toVariable(key, value) {
     return value ? `${key}: ${value};` : undefined;
@@ -118,9 +119,11 @@
           <h2 class="mzp-t-mozilla">
             <slot name="title">Title.</slot>
           </h2>
-          <button class="dismiss" on:click={onDismiss}>
-            <Close size="28px" />
-          </button>
+          {#if showCloseButton}
+            <button class="dismiss" on:click={onDismiss}>
+              <Close size="28px" />
+            </button>
+          {/if}
         </header>
 
         <div class={classSet}>

--- a/src/lib/components/study-card/StudyCard.svelte
+++ b/src/lib/components/study-card/StudyCard.svelte
@@ -35,7 +35,7 @@
     <span slot="study-top-section">
       {#if joined}
         <div
-          class={`vertically-aligned-container status-container ${
+          class={`d-flex status-container ${
             connected ? "connected" : "not-connected"
           }`}
         >
@@ -102,7 +102,7 @@
 
     <div class="joined-study-accordion">
       <AccordionButton bind:revealed>
-        <h4 class="study-card-subheader text-display-xxs">Study Description</h4>
+        <h4 class="study-card-subheader text-display-xxs">About this study</h4>
       </AccordionButton>
     </div>
 
@@ -181,7 +181,6 @@
 
     box-shadow: var(--rally-box-shadow-sm);
     background-color: var(--color-white);
-    border: 1px solid #ececed;
   }
 
   .study-card-description {
@@ -302,21 +301,35 @@
 
   .update-dropdown-link {
     text-decoration: none;
-    height: 28px;
-    width: 28px;
-  }
-
-  .update-dropdown-link:global(.show) {
-    background-color: #ededf0;
     border-radius: 50%;
     height: 28px;
     width: 28px;
+    box-shadow: none;
+  }
+
+  .update-dropdown-link:hover {
+    background-color: #cdcdd499;
+  }
+
+  .update-dropdown-link:global(.show) {
+    background-color: #c8c8d0;
   }
 
   .status-container {
     justify-content: space-between;
-    padding-left: 16px;
-    padding-right: 10px;
+    align-items: center;
+    padding-left: 24px;
+    padding-right: 24px;
+    padding-top: 11px;
+    padding-bottom: 11px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+
+  @media (max-width: 480px) {
+    .status-container {
+      align-items: flex-start;
+    }
   }
 
   .status-container.connected {
@@ -325,5 +338,9 @@
 
   .status-container.not-connected {
     background: #ffe3c2;
+  }
+
+  .dropdown-menu li {
+    display: flex;
   }
 </style>

--- a/src/lib/components/study-card/StudyStatusBadge.svelte
+++ b/src/lib/components/study-card/StudyStatusBadge.svelte
@@ -6,31 +6,35 @@
   export let downloadUrl;
 </script>
 
-<div class="vertically-aligned-container status-container">
-  <div class="vertically-aligned-container">
-    <span style="margin-right: 5px" class="vertically-aligned-container">
-      {#if connected}
-        <CheckCircle size="20px" color="var(--color-green-60)" />
-      {:else}
-        <Exclaimation size="20px" color="#FFA436" />
-      {/if}
-    </span>
+<div class="status-container">
+  <span style="margin-right: 5px" class="d-flex">
     {#if connected}
-      <span class="text-body-sm connected title">You're participating</span>
+      <CheckCircle size="20px" color="var(--color-green-60)" />
     {:else}
-      <span class="text-body-sm not-connected title"
-        >Not Participating. <a href={downloadUrl} target="_blank"
-          >Add this study extension from the Chrome store.</a
-        ></span
-      >
+      <Exclaimation size="20px" color="#FFA436" />
     {/if}
-  </div>
+  </span>
+  {#if connected}
+    <span class="text-body-sm connected title">You're participating</span>
+  {:else}
+    <span class="text-body-sm not-connected title"
+      >You're not participating yet. <a href={downloadUrl} target="_blank"
+        >Add this study extension from the Chrome store.</a
+      ></span
+    >
+  {/if}
 </div>
 
 <style>
   .status-container {
-    margin-top: 11px;
-    margin-bottom: 11px;
+    display: flex;
+    align-items: center;
+  }
+
+  @media (max-width: 480px) {
+    .status-container {
+      align-items: flex-start;
+    }
   }
 
   .status-container .not-connected.title {

--- a/src/lib/views/studies/Content.svelte
+++ b/src/lib/views/studies/Content.svelte
@@ -52,7 +52,7 @@
 
   <Accordion revealed={true}>
     <div slot="title">How to join a study</div>
-    <slot><StudyUsageTooltip class="pb-0 mb-0" /></slot>
+    <slot><StudyUsageTooltip class="mb-0" /></slot>
   </Accordion>
 
   <div class="studies">

--- a/src/lib/views/studies/StudyCard.svelte
+++ b/src/lib/views/studies/StudyCard.svelte
@@ -72,6 +72,7 @@
     height={joined ? undefined : "auto"}
     topPadding={joined ? undefined : "calc(10vh - 20px)"}
     width={joined ? "var(--content-width)" : undefined}
+    showCloseButton={false}
     on:dismiss={() => {
       joinModal = false;
     }}
@@ -134,7 +135,7 @@
     <div class="modal-call-flow" slot="cta">
       <Button
         size="lg"
-        product
+        neutral
         secondary
         on:click={() => {
           joinModal = false;

--- a/src/lib/views/studies/StudyUsageTooltip.svelte
+++ b/src/lib/views/studies/StudyUsageTooltip.svelte
@@ -35,7 +35,7 @@
     display: flex;
     flex-direction: row;
     align-items: flex-start;
-    padding: 24px;
+    padding: 20px;
     list-style-type: none;
 
     background: #ffffff;
@@ -100,5 +100,28 @@
     line-height: 18px;
     text-align: center;
     color: #5e5e72;
+  }
+
+  @media (max-width: 480px) {
+    .container {
+      flex-direction: column;
+      padding: 12px;
+    }
+
+    .container li {
+      border: none !important;
+      padding-left: 0px !important;
+    }
+
+    .container li::before {
+      align-self: unset;
+      position: absolute;
+    }
+
+    .container h1,
+    .container p {
+      text-align: unset !important;
+      margin-left: 36.65px;
+    }
   }
 </style>


### PR DESCRIPTION
This is a followup PR that fixes minor UI gaps that were identified in https://github.com/mozilla-rally/rally-web-platform/pull/337:

Make tooltip responsive
Get rid of X in Dialog (make it conditional)
Menu span out bug

Screenshots:

Responsive tooltip:

<img width="408" alt="image" src="https://user-images.githubusercontent.com/85543848/166624212-519b63dc-27d1-4aae-9a79-27cd112b4305.png">
