### PR TITLE
enable prod deploys (just via circle-ci for now)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
             branches:
               only: master
 
-      - site-deploy: # This deploys to our stage site at https://stage.rally-web.nonprod.dataops.mozgcp.net
+      - site-deploy: # This deploys to our stage site at https://stage.rally-web.nonprod.dataops.mozgcp.net / https://members.rally.allizom.org
           context: rally-web
           project_name: $PROJECT_ID_STAGE
           project_config: rally-web-stage
@@ -129,19 +129,19 @@ workflows:
               only: /.*/
             branches:
               only: master
-#      - hold: # requires approval for prod deployment
-#          type: approval
-#          requires:
-#            - site-deploy
-#      - site-deploy: # This deploys directly to our prod site at <unknown yet>
-#          context: rally-web
-#          project_name: $PROJECT_ID_PROD
-#           project_config: rally-web-prod
-#          service_account: $GCLOUD_SERVICE_KEY
-#          requires:
-#            - hold
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              only: master
+      - hold: # requires approval for prod deployment
+          type: approval
+          requires:
+            - site-deploy
+      - site-deploy: # This deploys directly to our prod site at https://prod.rally-web.prod.dataops.mozgcp.net / https://members.rally.mozilla.org
+          context: rally-web
+          project_name: $PROJECT_ID_PROD
+          project_config: rally-web-prod
+          service_account: $GCLOUD_SERVICE_KEY
+          requires:
+            - hold
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ workflows:
 
       - site-deploy: # This deploys to our stage site at https://stage.rally-web.nonprod.dataops.mozgcp.net / https://members.rally.allizom.org
           context: rally-web
+          name: stage-site-deploy
           project_name: $PROJECT_ID_STAGE
           project_config: rally-web-stage
           service_key: $GCLOUD_SERVICE_KEY
@@ -129,15 +130,18 @@ workflows:
               only: /.*/
             branches:
               only: master
+
       - hold: # requires approval for prod deployment
           type: approval
           requires:
-            - site-deploy
+            - stage-site-deploy
+
       - site-deploy: # This deploys directly to our prod site at https://prod.rally-web.prod.dataops.mozgcp.net / https://members.rally.mozilla.org
           context: rally-web
+          name: prod-site-deploy
           project_name: $PROJECT_ID_PROD
           project_config: rally-web-prod
-          service_account: $GCLOUD_SERVICE_KEY
+          service_key: $GCLOUD_SERVICE_KEY
           requires:
             - hold
           filters:

--- a/config/firebase.config.rally-web-prod.json
+++ b/config/firebase.config.rally-web-prod.json
@@ -1,0 +1,9 @@
+{
+  "apiKey": "AIzaSyAv_gSjNRMbEq3BFCNHPn0soXMCx2IxLeM",
+  "authDomain": "moz-fx-data-rally-w-prod-dfa4.firebaseapp.com",
+  "projectId": "moz-fx-data-rally-w-prod-dfa4",
+  "storageBucket": "moz-fx-data-rally-w-prod-dfa4.appspot.com",
+  "messagingSenderId": "982322764946",
+  "appId": "1:982322764946:web:f9b6aea488cebde47ada4b",
+  "functionsHost": "https://us-central1-moz-fx-data-rally-w-prod-dfa4.cloudfunctions.net"
+}


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/DSRE-637

What this PR does:
* adds firebase prod rally-web app json config file
* updates circleci deployment baseline to also now deploy prod => members.rally.mozilla.org
* updates circleci deployment note of possibly simpler to remember stage domain => members.rally.allizom.org

Next steps:
* still setting up the clickops stuff in prod, but ready for the team to start reviewing and poking at, perhaps try an automating deploy to


prod: members.rally.mozilla.org
stage (feel free to continue to use other domain too): members.rally.allizom.org (cert still created at time of writing this PR, fyi)