### PR TITLE
only run pause & prod deploy when tags are created

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,9 @@ workflows:
           type: approval
           requires:
             - stage-site-deploy
+          filters:
+            tags:
+              only: /.*/
 
       - site-deploy: # This deploys directly to our prod site at https://prod.rally-web.prod.dataops.mozgcp.net / https://members.rally.mozilla.org
           context: rally-web
@@ -147,5 +150,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-            branches:
-              only: master


### PR DESCRIPTION
Jira: follows up on https://mozilla-hub.atlassian.net/browse/DSRE-637

What this PR does:
* only do a prod deploy (and waiting for a prod deploy) when a Git Tag is created / pushed
* yes, this means stage builds & deploys run on tag releases too, but separating this out for a cleaning dev=>stage=>prod process should probably take a little more thought, and this was low hanging fruit