### PR TITLE
do not hold for second sign-off, push to prod on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-and-test:
-          filters:
-            tags:
-              only: /.*/
-
+      - build-and-test
       - archive-site:
           requires:
             - build-and-test
@@ -128,6 +124,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              ignore: /.*/
 
       - site-deploy: # This deploys directly to our prod site at https://prod.rally-web.prod.dataops.mozgcp.net / https://members.rally.mozilla.org
           context: rally-web
@@ -135,6 +133,10 @@ workflows:
           project_name: $PROJECT_ID_PROD
           project_config: rally-web-prod
           service_key: $GCLOUD_SERVICE_KEY
+          requires:
+            - archive-site
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,6 @@ workflows:
           requires:
             - archive-site
           filters:
-            tags:
-              only: /.*/
             branches:
               only: master
 
@@ -137,8 +135,6 @@ workflows:
           project_name: $PROJECT_ID_PROD
           project_config: rally-web-prod
           service_key: $GCLOUD_SERVICE_KEY
-          requires:
-            - stage-site-deploy
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       # Checkout the code as the first step.
       - checkout
       - node/install:
-          node-version: '16.13'
+          node-version: "16.13"
       - node/install-packages
       - run:
           name: Run lint
@@ -131,14 +131,6 @@ workflows:
             branches:
               only: master
 
-      - hold: # requires approval for prod deployment
-          type: approval
-          requires:
-            - stage-site-deploy
-          filters:
-            tags:
-              only: /.*/
-
       - site-deploy: # This deploys directly to our prod site at https://prod.rally-web.prod.dataops.mozgcp.net / https://members.rally.mozilla.org
           context: rally-web
           name: prod-site-deploy
@@ -146,7 +138,7 @@ workflows:
           project_config: rally-web-prod
           service_key: $GCLOUD_SERVICE_KEY
           requires:
-            - hold
+            - stage-site-deploy
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
Currently we are using a Circle CI feature where it waits for human sign-off before pushing to production, but I don't think we really need that right now. I think we also shouldn't push to stage on tags, it should only be `master` (because we might be tagging from a release branch etc)

I think this is the way we want it to work:

- push to `master` deploys to stage
- pushing a new tag deploys that tag to production