### PR TITLE
When user is not connected to a study then:

### DIFF
--- a/src/lib/components/study-card/StudyCard.svelte
+++ b/src/lib/components/study-card/StudyCard.svelte
@@ -63,7 +63,8 @@
                 <a
                   class="dropdown-item text-body-sm"
                   on:click={() => dispatch("leave")}
-                  href="#">Leave study</a
+                  href="#"
+                  >{connected ? "Leave study" : "Don't join this study"}</a
                 >
               </li>
             </ul>

--- a/src/lib/stores/types.ts
+++ b/src/lib/stores/types.ts
@@ -37,7 +37,9 @@ export interface UserStudies {
 
 export interface UserStudy {
   joinedOn: { seconds: number; nanoseconds: number; };
-  enrolled: false;
+  enrolled: boolean;
+  attached: boolean;
+  studyId: string;
 }
 
 export interface StudyMetadata {

--- a/src/lib/views/studies/StudyCard.svelte
+++ b/src/lib/views/studies/StudyCard.svelte
@@ -34,12 +34,19 @@
   const dispatch = createEventDispatcher();
 
   let joinModal = false;
+  let leaveModal = false;
 
   function triggerJoinEvent() {
     // send CTA click event to parent.
     dispatch("cta-clicked");
-    joinModal = true;
+
+    if (connected || !joined) {
+      joinModal = true;
+    } else {
+      leaveModal = true;
+    }
   }
+
   let Dialog;
   let mounted = false;
   onMount(async () => {
@@ -66,6 +73,51 @@
     {description}
   </p>
 </StudyCard>
+
+{#if leaveModal && Dialog}
+  <Dialog
+    width={"482px"}
+    showCloseButton={false}
+    on:dismiss={() => {
+      leaveModal = false;
+    }}
+  >
+    <div slot="title" class="dialog-title">
+      Confirm if you want to join this study or not
+    </div>
+
+    <div slot="body" class="dialog-body">
+      You previously started to join this study, but didn’t finish the process
+      by installing the study extension from the Chrome Web Store.
+    </div>
+
+    <div class="modal-call-flow" slot="cta">
+      <Button
+        size="lg"
+        neutral
+        secondary
+        leave
+        on:click={() => {
+          window.open(downloadUrl, "_blank");
+          leaveModal = false;
+        }}
+      >
+        Add study extension
+      </Button>
+
+      <Button
+        size="lg"
+        product
+        on:click={() => {
+          dispatch("leave");
+          leaveModal = false;
+        }}
+      >
+        Don't join this study
+      </Button>
+    </div>
+  </Dialog>
+{/if}
 
 {#if joinModal && mounted && Dialog}
   <Dialog
@@ -179,5 +231,18 @@
     font-weight: 600;
     font-size: 16px;
     line-height: 24px;
+  }
+
+  .dialog-title {
+    margin-bottom: 24px;
+  }
+
+  .dialog-body {
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 24px;
+    margin-bottom: 40px;
+    margin-right: 20px;
+    color: #5e5e72;
   }
 </style>

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -187,11 +187,11 @@ describe("Rally Web Platform UX flows", function () {
       e.click()
     );
 
-    await findAndAct(driver, By.xpath('//a[text()="Leave study"]'), (e) =>
+    await findAndAct(driver, By.xpath('//a[text()="Don\'t join this study"]'), (e) =>
       e.click()
     );
 
-    await findAndAct(driver, By.xpath('//button[text()="Cancel"]'), (e) =>
+    await findAndAct(driver, By.xpath('//html'), (e) =>
       e.click()
     );
 
@@ -200,13 +200,13 @@ describe("Rally Web Platform UX flows", function () {
       e.click()
     );
 
-    await findAndAct(driver, By.xpath('//a[text()="Leave study"]'), (e) =>
+    await findAndAct(driver, By.xpath('//a[text()="Don\'t join this study"]'), (e) =>
       e.click()
     );
 
     await findAndAct(
       driver,
-      By.xpath('(//button[text()="Leave Study"])'),
+      By.xpath('(//button[text()="Don\'t join this study"])'),
       (e) => e.click()
     );
 


### PR DESCRIPTION
When user is not connected to a study then:
* Re-word the leave to "don't join this study"
* Display new modal dialog to handle open extension dialog or to leave

Screenshots:

New "Don't join this study" option:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/85543848/167539580-1597eebd-e83e-4613-8c07-fcab40d04693.png">

New modal dialog:
<img width="514" alt="image" src="https://user-images.githubusercontent.com/85543848/167539644-588e5e76-de87-4f9a-a491-6fb143f65115.png">
