### PR TITLE
Styled join and leave study modal dialogs

### DIFF
--- a/src/lib/views/irb/FacebookPixelHunt.svelte
+++ b/src/lib/views/irb/FacebookPixelHunt.svelte
@@ -1,46 +1,59 @@
-<h1>
-  You are joining the Facebook Pixel Hunt, a study by Mozilla Rally and The
-  Markup.
-</h1>
+<div class="container">
+  <h1>
+    You are joining the Facebook Pixel Hunt, a study by Mozilla Rally and The
+    Markup.
+  </h1>
 
-<h2>How to join this study</h2>
+  <div class="container-body">
+    <h2>How to join this study</h2>
 
-<ol style="list-style: auto; list-style-position: inside;">
-  <li>
-    Click on "Add study extension” below. This will open the Chrome Web Store.
-  </li>
-  <li>
-    There, click on "Add to Chrome.” This will add this study's extension to
-    your browser.
-  </li>
-  <li>
-    You will be brought back to the Rally website. Here you will see that you
-    have joined the study and are contributing your browsing data.
-  </li>
-</ol>
+    <ol style="list-style: auto; list-style-position: inside;">
+      <li>
+        Click on "Add study extension” below. This will open the Chrome Web
+        Store.
+      </li>
+      <li>
+        There, click on "Add to Chrome.” This will add this study's extension to
+        your browser.
+      </li>
+      <li>
+        You will be brought back to the Rally website. Here you will see that
+        you have joined the study and are contributing your browsing data.
+      </li>
+    </ol>
 
-<h2>About the study</h2>
+    <h2>About the study</h2>
 
-<p>
-  The Markup will use the browsing data collected in this study to map
-  Facebook's tracking pixel network across the web. Read more about this study
-  on the Rally website. The Markup will publish its findings as news stories at
-  themarkup.org.
-</p>
+    <p>
+      The Markup will use the browsing data collected in this study to map
+      Facebook's tracking pixel network across the web. Read more about this
+      study on the Rally website. The Markup will publish its findings as news
+      stories at themarkup.org.
+    </p>
 
-<h2>Leaving the study</h2>
+    <h2>Leaving the study</h2>
 
-<p>
-  You can leave the study anytime from the Rally Studies page, found by clicking
-  on the Rally icon <img
-    style="padding: 0 4px;"
-    width="16"
-    src="img/rally-toolbar-icon.svg"
-    alt="rally icon"
-  /> in your browser toolbar.
-</p>
+    <p>
+      You can leave the study anytime from the Rally Studies page, found by
+      clicking on the Rally icon <img
+        style="padding: 0 4px;"
+        width="16"
+        src="img/rally-toolbar-icon.svg"
+        alt="rally icon"
+      /> in your browser toolbar.
+    </p>
+  </div>
+</div>
 
 <style>
+  .container {
+    margin-right: 90px;
+  }
+
+  .container-body {
+    padding-right: 10px;
+  }
+
   h1,
   h2,
   p {

--- a/src/lib/views/studies/StudyCard.svelte
+++ b/src/lib/views/studies/StudyCard.svelte
@@ -123,7 +123,7 @@
   <Dialog
     height={joined ? undefined : "auto"}
     topPadding={joined ? undefined : "calc(10vh - 20px)"}
-    width={joined ? "var(--content-width)" : undefined}
+    width={joined ? "673px" : undefined}
     showCloseButton={false}
     on:dismiss={() => {
       joinModal = false;
@@ -158,29 +158,34 @@
           {/if}
         </IRBWindow>
       {:else}
-        <div style="width: 400px;">
+        <div>
           <p class="leave-tagline">You’re free to come and go as you please.</p>
-          <p class="leave-sub-tagline">Leaving a study means:</p>
-          <ul class="mzp-u-list-styled bigger-gap" style="padding-right: 48px;">
-            <li>
-              <b>You will only be leaving this specific study</b>. You will
-              continue contributing your browsing data to any other studies
-              you've joined.
-            </li>
-            <li>
-              <b>You will stop contributing browsing data to this study</b> and the
-              researchers leading this study.
-            </li>
-            <li>
-              <b>Rally will delete all your data from this study.</b>
-            </li>
-          </ul>
+          <div class="d-flex flex-row">
+            <div style="width: 316px;">
+              <p class="leave-sub-tagline">Leaving a study means:</p>
+              <ul class="mzp-u-list-styled bigger-gap">
+                <li>
+                  <b>You will only be leaving this specific study</b>. You will
+                  continue contributing your browsing data to any other studies
+                  you've joined.
+                </li>
+                <li>
+                  <b>You will stop contributing browsing data to this study</b> and
+                  the researchers leading this study.
+                </li>
+                <li>
+                  <b>Rally will delete all your data from this study.</b>
+                </li>
+              </ul>
+            </div>
+
+            <img
+              style="width: 316px; padding-top: 20px; transform: translateX(-24px);"
+              src="img/leave-this-study.png"
+              alt="person considering leaving the study"
+            />
+          </div>
         </div>
-        <img
-          style="width: 264px; max-height: 312px; padding-top: 20px; transform: translateX(-24px);"
-          src="img/leave-this-study.png"
-          alt="person considering leaving the study"
-        />
       {/if}
     </div>
     <!-- if the leave study modal is present, shore up the button hheights -->
@@ -207,7 +212,7 @@
           joinModal = false;
         }}
       >
-        {#if joined}Leave Study{:else}Accept & Enroll{/if}
+        {#if joined}Leave Study{:else}Add study extension{/if}
       </Button>
     </div>
   </Dialog>

--- a/tests/integration/ux.test.ts
+++ b/tests/integration/ux.test.ts
@@ -163,7 +163,7 @@ describe("Rally Web Platform UX flows", function () {
     );
     await findAndAct(
       driver,
-      By.xpath('//button[text()="Accept & Enroll"]'),
+      By.xpath('//button[text()="Add study extension"]'),
       (e) => e.click()
     );
 


### PR DESCRIPTION
Fixes: https://github.com/mozilla-rally/rally-web-platform/issues/403

Screenshots:

Join Study:
<img width="739" alt="image" src="https://user-images.githubusercontent.com/85543848/167992031-2abbfa64-02cb-4ca1-8e32-104843d86575.png">

Leave Study:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/85543848/167991933-6d704567-0149-4903-9a20-3abdd54a7df5.png">
