### PR TITLE
use official website name as authDomain

### DIFF
--- a/config/firebase.config.rally-web-prod.json
+++ b/config/firebase.config.rally-web-prod.json
@@ -1,6 +1,6 @@
 {
   "apiKey": "AIzaSyAv_gSjNRMbEq3BFCNHPn0soXMCx2IxLeM",
-  "authDomain": "moz-fx-data-rally-w-prod-dfa4.firebaseapp.com",
+  "authDomain": "members.rally.mozilla.org",
   "projectId": "moz-fx-data-rally-w-prod-dfa4",
   "storageBucket": "moz-fx-data-rally-w-prod-dfa4.appspot.com",
   "messagingSenderId": "982322764946",

--- a/config/firebase.config.rally-web-stage.json
+++ b/config/firebase.config.rally-web-stage.json
@@ -1,6 +1,6 @@
 {
   "apiKey": "AIzaSyAj3z6_cRdiBzwTuVzey6sJm0hVDVBSrDg",
-  "authDomain": "moz-fx-data-rall-nonprod-ac2a.firebaseapp.com",
+  "authDomain": "members.rally.allizom.org",
   "projectId": "moz-fx-data-rall-nonprod-ac2a",
   "storageBucket": "moz-fx-data-rall-nonprod-ac2a.appspot.com",
   "messagingSenderId": "451372671583",


### PR DESCRIPTION
Right now, the user-facing auth domain is set to our project's `{projectId}.firebaseapp.com` domain:

<img width="518" alt="image" src="https://user-images.githubusercontent.com/61412/168456561-954a91f1-3ff4-45ef-b871-4e46b352d014.png">

We should use the official names here instead.