### PR TITLE
complete-signup request now contains object not string in details

### DIFF
--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -122,15 +122,14 @@ export default {
       await initializeFirestoreAPIs();
 
       async function handleContentScriptEvents(e) {
-        console.log("message from content script received:", e.type, e);
-
         // Mark this study as connected.
         // TODO
         // this.updateStudyEnrollment(true, e.detail.studyId, true);
         switch (e.type) {
           case "rally-sdk.complete-signup":
 
-            const studyId = e.detail && e.detail.studyId;
+            const detail = JSON.parse(e.detail);
+            const studyId = detail && detail.studyId;
             if (!studyId) {
               throw new Error(
                 "handling rally-sdk.complete-signup from content script: No study ID provided."

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -129,14 +129,14 @@ export default {
         // this.updateStudyEnrollment(true, e.detail.studyId, true);
         switch (e.type) {
           case "rally-sdk.complete-signup":
-            // @ts-ignore
-            if (!e.detail && !e.detail.studyId) {
+
+            const studyId = e.detail && e.detail.studyId;
+            if (!studyId) {
               throw new Error(
                 "handling rally-sdk.complete-signup from content script: No study ID provided."
               );
             }
 
-            const studyId = e.detail.studyId;
             if (functionsHost === undefined) {
               throw new Error(
                 "Firebase Functions host not defined, cannot generate JWTs for extensions."

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -130,12 +130,13 @@ export default {
         switch (e.type) {
           case "rally-sdk.complete-signup":
             // @ts-ignore
-            const studyId = e.detail;
-            if (!studyId) {
+            if (!e.detail && !e.detail.studyId) {
               throw new Error(
                 "handling rally-sdk.complete-signup from content script: No study ID provided."
               );
             }
+
+            const studyId = e.detail.studyId;
             if (functionsHost === undefined) {
               throw new Error(
                 "Firebase Functions host not defined, cannot generate JWTs for extensions."

--- a/tests/integration/extension/package-lock.json
+++ b/tests/integration/extension/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@mozilla/rally-sdk": "^0.9.12",
+        "@mozilla/rally-sdk": "^0.9.14",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.2.1",
         "@rollup/plugin-replace": "^4.0.0",
@@ -818,9 +818,9 @@
       "dev": true
     },
     "node_modules/@mozilla/rally-sdk": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.12.tgz",
-      "integrity": "sha512-zNtdAycHzpxdjHo1ogeB8m3SInpuQd8TaNHjzq4f2wDdVyY8J0eKWuCkJjsnHB6cihwJvUVmSwzbbUt1JWTSXA==",
+      "version": "0.9.14",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.14.tgz",
+      "integrity": "sha512-zYwPTkaxPltsaT3UxG/D+Rjk5Les+DYjXD3QTViNlvpblw4+68B6SF+ADzErLxHKbuJP58h42ynPiRj+RIQA2Q==",
       "dev": true,
       "dependencies": {
         "firebase": "^9.6.10",
@@ -8210,9 +8210,9 @@
       "dev": true
     },
     "@mozilla/rally-sdk": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.12.tgz",
-      "integrity": "sha512-zNtdAycHzpxdjHo1ogeB8m3SInpuQd8TaNHjzq4f2wDdVyY8J0eKWuCkJjsnHB6cihwJvUVmSwzbbUt1JWTSXA==",
+      "version": "0.9.14",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.14.tgz",
+      "integrity": "sha512-zYwPTkaxPltsaT3UxG/D+Rjk5Les+DYjXD3QTViNlvpblw4+68B6SF+ADzErLxHKbuJP58h42ynPiRj+RIQA2Q==",
       "dev": true,
       "requires": {
         "firebase": "^9.6.10",

--- a/tests/integration/extension/package-lock.json
+++ b/tests/integration/extension/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@mozilla/rally-sdk": "^0.9.9",
+        "@mozilla/rally-sdk": "^0.9.12",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.2.1",
         "@rollup/plugin-replace": "^4.0.0",
@@ -818,9 +818,9 @@
       "dev": true
     },
     "node_modules/@mozilla/rally-sdk": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.9.tgz",
-      "integrity": "sha512-KKRg5PpuNbP7URWSJMHjjBQJSPbQlYsMyg34Nz4f6/Meq2Ea0MAQnfVcefhZ0peGiOV3A7hz9VCjwXxkfAYPEA==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.12.tgz",
+      "integrity": "sha512-zNtdAycHzpxdjHo1ogeB8m3SInpuQd8TaNHjzq4f2wDdVyY8J0eKWuCkJjsnHB6cihwJvUVmSwzbbUt1JWTSXA==",
       "dev": true,
       "dependencies": {
         "firebase": "^9.6.10",
@@ -8210,9 +8210,9 @@
       "dev": true
     },
     "@mozilla/rally-sdk": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.9.tgz",
-      "integrity": "sha512-KKRg5PpuNbP7URWSJMHjjBQJSPbQlYsMyg34Nz4f6/Meq2Ea0MAQnfVcefhZ0peGiOV3A7hz9VCjwXxkfAYPEA==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally-sdk/-/rally-sdk-0.9.12.tgz",
+      "integrity": "sha512-zNtdAycHzpxdjHo1ogeB8m3SInpuQd8TaNHjzq4f2wDdVyY8J0eKWuCkJjsnHB6cihwJvUVmSwzbbUt1JWTSXA==",
       "dev": true,
       "requires": {
         "firebase": "^9.6.10",

--- a/tests/integration/extension/package.json
+++ b/tests/integration/extension/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MPL-2.0",
   "devDependencies": {
-    "@mozilla/rally-sdk": "^0.9.12",
+    "@mozilla/rally-sdk": "^0.9.14",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
     "@rollup/plugin-replace": "^4.0.0",

--- a/tests/integration/extension/package.json
+++ b/tests/integration/extension/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MPL-2.0",
   "devDependencies": {
-    "@mozilla/rally-sdk": "^0.9.9",
+    "@mozilla/rally-sdk": "^0.9.12",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
     "@rollup/plugin-replace": "^4.0.0",


### PR DESCRIPTION
The SDK now sends `{studyId}` in `details`, where it used to just send the value of `studyId` as a string.