### PR TITLE
Remove unreachable post-redirect user creation code

### DIFF
--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -277,23 +277,11 @@ export default {
     // Allow user to select which Google account to use.
     provider.setCustomParameters({ prompt: "select_account" });
 
-    let userCredential;
     try {
-      userCredential = await signInWithRedirect(auth, provider);
+      await signInWithRedirect(auth, provider);
     } catch (err) {
       console.error("there was an error", err);
     }
-    // create a new user.
-    if (userCredential) {
-      console.debug("Logged in as", userCredential.user.email);
-      initializeUserDocument(userCredential.user.uid);
-      listenForUserChanges(userCredential.user);
-      listenForUserStudiesChanges(userCredential.user);
-    }
-
-    // Let the Rally SDK content script know the site is intialized.
-    console.debug("initialized, dispatching rally-sdk.web-check");
-    window.dispatchEvent(new CustomEvent("rally-sdk.web-check", {}));
   },
 
   async loginWithEmailAndPassword(email, password) {


### PR DESCRIPTION
`signInWithRedirect` returns `Promise<void>`, so I'm pretty sure this code is unreachable and wouldn't function if it were, we don't notice because the page redirects before the removed code can run.

The reason it works is because onAuthChange fires when the page reloads from the redirect. 

We could explicitly handle the redirect, but I'm not sure if there's any advantage vs. waiting for `onAuthChange` to fire (it always fires on first page load, with a null `userCredential` if not logged in)