### PR TITLE
Use the same email validation regex as HTML5 spec

### DIFF
--- a/src/lib/components/auth-cards/ForgetPWCard.svelte
+++ b/src/lib/components/auth-cards/ForgetPWCard.svelte
@@ -16,7 +16,7 @@
   export let sendUserInfo;
   export let storyBookTest;
 
-  const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+  const emailPattern = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
   const errorClass = "mzp-c-field-control mzp-c-field-control--error";
   const inputClass = "mzp-c-field-control";
   let customClass = "";

--- a/src/lib/components/auth-cards/SignInCard.svelte
+++ b/src/lib/components/auth-cards/SignInCard.svelte
@@ -11,7 +11,7 @@
   export let storyBookTest;
   export let handleTrigger;
 
-  const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+  const emailPattern = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
   const errorClass = "mzp-c-field-control mzp-c-field-control--error";
   const inputClass = "mzp-c-field-control";
 


### PR DESCRIPTION
The HTML5 spec includes a regular expression equivalent to what browsers use in the `<input type="email">` element:
https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address