### PR TITLE
Do not re-initialize after email login

### DIFF
--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -300,13 +300,14 @@ export default {
     let userCredential;
     try {
       userCredential = await signInWithEmailAndPassword(auth, email, password);
-      window.location.href = "/studies";
     } catch (err) {
       console.error("there was an error", err);
       localStorage.setItem("signInErr", err);
       return;
     }
-    if (!userCredential.user.emailVerified) {
+    if (userCredential.user.emailVerified) {
+      window.location.href = "/studies";
+    } else {
       console.warn("Email account not verified, sending verification email");
       localStorage.setItem("signInErr", "Email account not verified");
       await sendEmailVerification(userCredential.user);

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -266,7 +266,7 @@ export default {
     return initialState;
   },
 
-  async onAuthStateChanged(callback) {
+  async onAuthChanged(callback) {
     await initializeFirestoreAPIs();
     onAuthStateChanged(auth, callback);
   },
@@ -300,6 +300,7 @@ export default {
     let userCredential;
     try {
       userCredential = await signInWithEmailAndPassword(auth, email, password);
+      window.location.reload();
     } catch (err) {
       console.error("there was an error", err);
       localStorage.setItem("signInErr", err);
@@ -309,6 +310,7 @@ export default {
       console.warn("Email account not verified, sending verification email");
       localStorage.setItem("signInErr", "Email account not verified");
       await sendEmailVerification(userCredential.user);
+      await this.signOutUser();
     }
   },
 

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -266,7 +266,7 @@ export default {
     return initialState;
   },
 
-  async onAuthChanged(callback) {
+  async onAuthStateChanged(callback) {
     await initializeFirestoreAPIs();
     onAuthStateChanged(auth, callback);
   },

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -305,15 +305,7 @@ export default {
       localStorage.setItem("signInErr", err);
       return;
     }
-    if (userCredential.user.emailVerified) {
-      initializeUserDocument(userCredential.user.uid);
-      listenForUserChanges(userCredential.user);
-      listenForUserStudiesChanges(userCredential.user);
-
-      // Let the Rally SDK content script know the site is intialized.
-      console.debug("initialized, dispatching rally-sdk.web-check");
-      window.dispatchEvent(new CustomEvent("rally-sdk.web-check", {}));
-    } else {
+    if (!userCredential.user.emailVerified) {
       console.warn("Email account not verified, sending verification email");
       localStorage.setItem("signInErr", "Email account not verified");
       await sendEmailVerification(userCredential.user);

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -300,7 +300,7 @@ export default {
     let userCredential;
     try {
       userCredential = await signInWithEmailAndPassword(auth, email, password);
-      window.location.reload();
+      window.location.href = "/studies";
     } catch (err) {
       console.error("there was an error", err);
       localStorage.setItem("signInErr", err);

--- a/src/lib/stores/app-store.ts
+++ b/src/lib/stores/app-store.ts
@@ -102,7 +102,7 @@ export function createAppStore(api = firestoreAPI): AppStore {
  */
 function isAuthenticatedStore(): Readable<boolean> {
   const { subscribe, set } = writable(undefined);
-  firestoreAPI.onAuthStateChanged((authState) => {
+  firestoreAPI.onAuthChange((authState) => {
     set(authState !== null);
   });
   return { subscribe };

--- a/src/lib/stores/app-store.ts
+++ b/src/lib/stores/app-store.ts
@@ -102,7 +102,7 @@ export function createAppStore(api = firestoreAPI): AppStore {
  */
 function isAuthenticatedStore(): Readable<boolean> {
   const { subscribe, set } = writable(undefined);
-  firestoreAPI.onAuthChange((authState) => {
+  firestoreAPI.onAuthStateChanged((authState) => {
     set(authState !== null);
   });
   return { subscribe };


### PR DESCRIPTION
Similar to https://github.com/mozilla-rally/rally-web-platform/pull/439, new user initialization is handled in one place, the onAuthChange callback. Unlike that PR though, email is currently sending web-check message so it gets sent twice, which is causing https://github.com/mozilla-rally/rally-web-platform/issues/444

Fixes issue #444.