### PR TITLE
redirect to / after email login

### DIFF
--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -319,7 +319,7 @@ export default {
       return;
     }
     if (userCredential.user.emailVerified) {
-      window.location.href = "/studies";
+      window.location.href = "/";
     } else {
       console.warn("Email account not verified, sending verification email");
       localStorage.setItem("signInErr", "Email account not verified");


### PR DESCRIPTION
Redirect to / not /studies after email login, if /studies is visited with an unenrolled user then it shows this strange combination of both pages:

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/61412/169442334-e400380e-6bc5-424f-bd60-35717aa0b0c6.png">

It's still functional it seems (it even passes tests!) but it doesn't look right :) 