### PR TITLE
Add schemaNamespace to study un/enrollment pings

### DIFF
--- a/functions/src/glean.ts
+++ b/functions/src/glean.ts
@@ -112,7 +112,8 @@ export async function demographics(
  */
 export async function studyEnrollment(
   rallyID: string,
-  studyID: string
+  studyID: string,
+  schemaNamespace: string
 ): Promise<void> {
   if (!ENABLE_GLEAN) return;
   const releaseGlean = await gleanLock.acquire();
@@ -120,6 +121,7 @@ export async function studyEnrollment(
 
   rallyMetrics.id.set(rallyID);
   enrollmentMetrics.studyId.set(studyID);
+  enrollmentMetrics.schemaNamespace.set(schemaNamespace);
 
   await submitPingFlag.acquire();
   rallyPings.studyEnrollment.submit();
@@ -134,7 +136,8 @@ export async function studyEnrollment(
  */
 export async function studyUnenrollment(
   rallyID: string,
-  studyID: string
+  studyID: string,
+  schemaNamespace: string
 ): Promise<void> {
   if (!ENABLE_GLEAN) return;
   const releaseGlean = await gleanLock.acquire();
@@ -142,6 +145,7 @@ export async function studyUnenrollment(
 
   rallyMetrics.id.set(rallyID);
   unenrollmentMetrics.studyId.set(studyID);
+  unenrollmentMetrics.schemaNamespace.set(schemaNamespace);
 
   await submitPingFlag.acquire();
   rallyPings.studyUnenrollment.submit();

--- a/functions/src/studies.ts
+++ b/functions/src/studies.ts
@@ -13,6 +13,7 @@ export const studies = {
     firefoxAddonId: "facebook-pixel-hunt@rally.mozilla.org",
     chromeExtensionId: "pbeklachfkbjddmglcccopmknmpfchdm",
     studyId: "facebookPixelHunt",
+    schemaNamespace: "rally-markup-fb-pixel-hunt",
     downloadLink: "https://chrome.google.com/webstore/detail/facebook-pixel-hunt/pbeklachfkbjddmglcccopmknmpfchdm",
     endDate: "2022-07-13",
     studyEnded: false,


### PR DESCRIPTION
Looks like the cloud task stuff will still take a while, so creating a separate PR for this so that we can get schemaNamespace into our pings before Foxfooding starts.