### PR TITLE
Fix: https://github.com/mozilla-rally/rally-web-platform/issues/471

### DIFF
--- a/src/lib/components/study-card/StudyCard.svelte
+++ b/src/lib/components/study-card/StudyCard.svelte
@@ -2,8 +2,7 @@
   /* This Source Code Form is subject to the terms of the Mozilla Public
    * License, v. 2.0. If a copy of the MPL was not distributed with this
    * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-  import { createEventDispatcher, getContext } from "svelte";
-  import type { Readable } from "svelte/store";
+  import { createEventDispatcher } from "svelte";
   import { slide } from "svelte/transition";
   import AccordionButton from "../accordion/AccordionButton.svelte";
   import Button from "../Button.svelte";
@@ -13,15 +12,12 @@
   import studyCategories from "./study-categories";
   import StudyStatusBadge from "./StudyStatusBadge.svelte";
 
-  const isExtensionConnected: Readable<boolean> = getContext(
-    "rally:isExtensionConnected"
-  );
-
   let revealed = false;
 
   export let endDate;
   export let downloadUrl;
   export let joined = false;
+  export let connected = false;
   export let studyDetailsLink = undefined;
   export let imageSrc;
   export let dataCollectionDetails = [];
@@ -37,42 +33,46 @@
 <div class="study-card-container radius-sm">
   <Header {endDate}>
     <span slot="study-top-section">
-      {#if joined}
+      {#if joined || connected}
         <div
           class={`d-flex status-container ${
-            $isExtensionConnected ? "connected" : "not-connected"
+            joined && connected ? "connected" : "not-connected"
           }`}
         >
-          <StudyStatusBadge {$isExtensionConnected} {downloadUrl} />
-          <div class="dropdown">
-            <button
-              class="btn btn-link update-dropdown-link p-0 pt-0 d-flex align-items-center"
-              type="button"
-              data-bs-toggle="dropdown"
-              aria-expanded="false"
-            >
-              <OverflowEllipsis color="#5E5E72" size="28px" />
-            </button>
-            <ul class="dropdown-menu dropdown-menu-bottom overflow-hidden">
-              {#if !$isExtensionConnected}
+          <StudyStatusBadge {joined} {connected} {downloadUrl} />
+          {#if !connected || joined}
+            <div class="dropdown">
+              <button
+                class="btn btn-link update-dropdown-link p-0 pt-0 d-flex align-items-center"
+                type="button"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+              >
+                <OverflowEllipsis color="#5E5E72" size="28px" />
+              </button>
+
+              <ul class="dropdown-menu dropdown-menu-bottom overflow-hidden">
+                {#if !connected}
+                  <li>
+                    <a
+                      class="dropdown-item text-body-sm"
+                      href={downloadUrl}
+                      target="_blank">Add study extension</a
+                    >
+                  </li>
+                {/if}
+
                 <li>
                   <a
                     class="dropdown-item text-body-sm"
-                    href={downloadUrl}
-                    target="_blank">Add study extension</a
+                    on:click={() => dispatch("leave")}
+                    href="#"
+                    >{connected ? "Leave study" : "Don't join this study"}</a
                   >
                 </li>
-              {/if}
-              <li>
-                <a
-                  class="dropdown-item text-body-sm"
-                  on:click={() => dispatch("leave")}
-                  href="#"
-                  >{$isExtensionConnected ? "Leave study" : "Don't join this study"}</a
-                >
-              </li>
-            </ul>
-          </div>
+              </ul>
+            </div>
+          {/if}
         </div>
         <hr class="header-divider mb-0" />
       {/if}

--- a/src/lib/components/study-card/StudyStatusBadge.svelte
+++ b/src/lib/components/study-card/StudyStatusBadge.svelte
@@ -1,33 +1,31 @@
 <script lang="ts">
-  import { getContext } from "svelte";
-  import type { Readable } from "svelte/store";
-
   import CheckCircle from "../icons/CheckCircle.svelte";
   import Exclaimation from "../icons/Exclaimation.svelte";
 
-  const isExtensionConnected: Readable<boolean> = getContext(
-    "rally:isExtensionConnected"
-  );
-
+  export let joined;
+  export let connected;
   export let downloadUrl;
 </script>
 
 <div class="status-container">
   <span style="margin-right: 5px" class="d-flex">
-    {#if $isExtensionConnected}
+    {#if joined && connected}
       <CheckCircle size="20px" color="var(--color-green-60)" />
     {:else}
       <Exclaimation size="20px" color="#FFA436" />
     {/if}
   </span>
-  {#if $isExtensionConnected}
+  {#if joined && connected}
     <span class="text-body-sm connected title">You're participating</span>
   {:else}
     <span class="text-body-sm not-connected title"
-      >You're not participating yet. <a href={downloadUrl} target="_blank"
-        >Add this study extension from the Chrome store.</a
-      ></span
-    >
+      >You're not participating yet.
+      {#if !connected}
+        <a href={downloadUrl} target="_blank"
+          >Add this study extension from the Chrome store.</a
+        >
+      {/if}
+    </span>
   {/if}
 </div>
 

--- a/src/lib/views/studies/Content.svelte
+++ b/src/lib/views/studies/Content.svelte
@@ -7,7 +7,7 @@
 
   import { createEventDispatcher } from "svelte";
   import { fly } from "svelte/transition";
-  import StudyCard from "./StudyCard.svelte";
+  import StudyCardContainer from "./StudyCardContainer.svelte";
   import StudyUsageTooltip from "./StudyUsageTooltip.svelte";
 
   export let studies = [];
@@ -57,7 +57,7 @@
 
   <div class="studies">
     {#each studies as study, i (study.studyId)}
-      <StudyCard
+      <StudyCardContainer
         title={study.name}
         author={study.authors.name}
         joined={study.studyId in userStudies &&

--- a/src/lib/views/studies/StudyCardContainer.svelte
+++ b/src/lib/views/studies/StudyCardContainer.svelte
@@ -11,13 +11,13 @@
 */
 
   import { createEventDispatcher, getContext, onMount } from "svelte";
-  import StudyCard from "../../components/study-card/StudyCard.svelte";
-  import StudyCardHeader from "../../components/study-card/Header.svelte";
-  import Button from "../../components/Button.svelte";
-  import IRBWindow from "../irb/IRBWindow.svelte";
-  import GenericConsent from "../irb/GenericConsent.svelte";
-  import irb from "../irb";
   import type { Readable } from "svelte/store";
+  import Button from "../../components/Button.svelte";
+  import StudyCardHeader from "../../components/study-card/Header.svelte";
+  import StudyCard from "../../components/study-card/StudyCard.svelte";
+  import irb from "../irb";
+  import GenericConsent from "../irb/GenericConsent.svelte";
+  import IRBWindow from "../irb/IRBWindow.svelte";
 
   const isExtensionConnected: Readable<boolean> = getContext(
     "rally:isExtensionConnected"
@@ -61,7 +61,7 @@
 
 <StudyCard
   {joined}
-  {$isExtensionConnected}
+  connected={$isExtensionConnected}
   on:join={triggerJoinEvent}
   on:leave={triggerJoinEvent}
   {endDate}


### PR DESCRIPTION
* Also renamed StudyCard within studies folder to be StudyCardContainer as there is another component by the name StudyCard
* Pass connected state instead of multiple store subscribers

Here are the various states now:

* Joined and Connected
<img width="697" alt="image" src="https://user-images.githubusercontent.com/85543848/170167288-ee6cd096-4d46-49e4-a2b8-d1e580a9f0ef.png">

* Joined but not connected
<img width="700" alt="image" src="https://user-images.githubusercontent.com/85543848/170170855-0c08a80f-70cb-4546-9962-666fe940cdd7.png">

* Connected but not joined (extension installed but study not joined)
<img width="698" alt="image" src="https://user-images.githubusercontent.com/85543848/170170928-2724a7f0-57f5-47ed-bb27-6da6fe7426bf.png">

* Not connected and not joined
<img width="702" alt="image" src="https://user-images.githubusercontent.com/85543848/170170991-82010a94-cdbf-4356-8fee-2765cb91a06a.png">

