### PR TITLE
replace quotes with bold on Join Study text on How to Join a study text

### DIFF
--- a/src/lib/views/studies/StudyUsageTooltip.svelte
+++ b/src/lib/views/studies/StudyUsageTooltip.svelte
@@ -15,7 +15,7 @@
   <li>
     <h1>Join the Study</h1>
     <p>
-      Click the “Join Study” button. We'll ask you to confirm in a pop-up dialog
+      Click the <b>Join Study</b> button. We'll ask you to confirm in a pop-up dialog
       by clicking the <b>Add Study Extension</b> button. This will open up the Chrome
       Web Store.
     </p>


### PR DESCRIPTION
Correcting an inconsistency with the text in step 2. Replacing quotes around Join Study with bold.

Before:

<img width="757" alt="Screen Shot 2022-05-24 at 5 12 38 PM" src="https://user-images.githubusercontent.com/444356/170367900-f5c19186-a5cd-431d-9bef-7e5c53516c5c.png">

After:

<img width="760" alt="Screen Shot 2022-05-25 at 5 09 20 PM" src="https://user-images.githubusercontent.com/444356/170367874-6d083c9a-9a8a-444c-a104-6f9477da1163.png">

