### PR TITLE
Add reauthentication step before deleting account

### DIFF
--- a/src/lib/stores/app-store.ts
+++ b/src/lib/stores/app-store.ts
@@ -57,8 +57,8 @@ export function createAppStore(api = firestoreAPI): AppStore {
     async getUserProvider(){
       return api.getUserProvider()
     },
-    async deleteUserAccount(){
-      return api.deleteUserAccount()
+    async deleteUserAccount(password){
+      return api.deleteUserAccount(password)
     },
     async updateOnboardedStatus(onboardingOrNot) {
       return api.updateOnboardedStatus(onboardingOrNot);

--- a/src/lib/views/account-settings/DeleteAccount.svelte
+++ b/src/lib/views/account-settings/DeleteAccount.svelte
@@ -7,18 +7,57 @@
   import type { AppStore } from "$lib/stores/types";
   import Button from "../../../lib/components/Button.svelte";
   import isMounted from "../../../lib/is-mounted";
+
   const dispatch = createEventDispatcher();
   const store: AppStore = getContext("rally:store");
+  const errorClass = "mzp-c-field-control mzp-c-field-control--error";
+  const inputClass = "mzp-c-field-control";
+
+  let btnDisabled = true;
+  let inputPasswordClass;
+  let inputItemsVisible = false;
+  let passwordEl;
+  let errText = null;
+  let passwordVisible = false;
+  let fireBaseErr = null;
 
   const offboardURL = "https://rally.mozilla.org/account-deleted";
   const mounted = isMounted();
 
   let leaveModal = false;
+  let isGoogleAccount;
   let Dialog;
 
   onMount(async () => {
+    inputPasswordClass = inputClass;
+    const userProvider = await store.getUserProvider();
+    isGoogleAccount =
+      userProvider &&
+      userProvider.length &&
+      userProvider[0].providerId &&
+      userProvider[0].providerId === "google.com";
+    btnDisabled = !isGoogleAccount;
     Dialog = (await import("../../../lib/components/Dialog.svelte")).default;
   });
+
+  const handleChange = (e) => {
+    const name = e.srcElement.name;
+    inputPasswordClass = inputClass;
+    errText = null;
+    btnDisabled = false;
+    if (name === "id_user_pw") {
+      inputItemsVisible = true;
+    }
+    if (passwordEl) {
+      if (passwordEl.value === "") {
+        btnDisabled = true;
+      }
+    }
+  };
+
+  const handleToggle = () => {
+    passwordVisible = !passwordVisible;
+  };
 
   const handleSelect = (type) => {
     dispatch("type", {
@@ -26,9 +65,40 @@
     });
   };
 
+  const handleNextState = () => {
+    /* if the input fields are not empty, check for firebase errors. */
+    fireBaseErr = localStorage.getItem("authErr");
+    if (fireBaseErr) {
+      setMessage();
+    } else {
+      leaveModal = false;
+      window.location.href = offboardURL;
+    }
+  };
+
+  const setMessage = () => {
+    const wrongPW = "auth/wrong-password";
+    const wrongUser = "auth/user-mismatch";
+    const popupBlocked = "auth/popup-blocked";
+    if (fireBaseErr.indexOf(wrongPW) > -1) {
+      errText =
+        "The password you entered is incorrect. Please try again.";
+      inputPasswordClass = errorClass;
+    }
+    if (fireBaseErr.indexOf(wrongUser) > -1) {
+      errText =
+        "The Google account you selected is not the one associated with your Rally account. Please try again.";
+    }
+    if (fireBaseErr.indexOf(popupBlocked) > -1) {
+      errText =
+        "The Google authentication popup was blocked by your browser. Please enable popups and try again.";
+    }
+  };
+
   async function deleteUserAccount() {
-    await store.deleteUserAccount();
-    window.location.href = offboardURL;
+    const password = !isGoogleAccount ? passwordEl.value : null;
+    await store.deleteUserAccount(password);
+    handleNextState();
   }
 </script>
 
@@ -94,9 +164,62 @@
     >
       <div style="width: 368px;">
         <p style="padding-top: 24px; font-size: 16px;">
-          This will permanently delete your account.
+          This will permanently delete your account. <br><br>
+          {#if isGoogleAccount}
+          <b>Note:</b> You may be asked to authenticate with Google to complete the process.
+          {:else}
+          Enter your password below to confirm.
+          {/if}
         </p>
+      {#if !isGoogleAccount}
+      <div class="label-wrapper">
+        <label class="mzp-c-field-label enter-pw" for="id_user_pw"
+          >Password</label
+        >
+        <!-- FORGOT PASSWORD -->
+        <!-- Will include this flow post mvp? -->
+        <!-- <label class="mzp-c-field-label forgot-pw" for="id_user_pw">
+          <button
+            on:click={() => {
+              handleTrigger("forget");
+            }}>Forgot password</button
+          ></label
+        > -->
       </div>
+      <div class="input-wrapper">
+        <!-- **** PASSWORD INPUT *** -->
+        <input
+          class={inputPasswordClass}
+          bind:this={passwordEl}
+          on:change={handleChange}
+          on:keyup={handleChange}
+          id="id_user_pw"
+          name="id_user_pw"
+          type={passwordVisible ? "text" : "password"}
+          width="100%"
+          required
+        />
+        <img
+          src={passwordVisible
+            ? "img/icon-password-show.svg"
+            : "img/icon-password-hide.svg"}
+          alt={passwordVisible ? "open eye" : "eye with slash"}
+          class={`toggle-password ${
+            inputItemsVisible ? "create-show" : "create-hide"
+          }`}
+          id="show-eye"
+          width="24px"
+          height="24px"
+          on:click={handleToggle}
+        />
+      </div>
+      {/if}
+      {#if errText}
+      <p class="error-msg error-msg--password">
+        {errText}
+      </p>
+    {/if}
+    </div>
     </div>
     <div class="modal-call-flow" slot="cta">
       <Button
@@ -114,12 +237,12 @@
         Cancel
       </Button>
       <Button
+        disabled={btnDisabled}
         size="xl"
         product
         leave
         customClass="card-button create"
         on:click={async () => {
-          leaveModal = false;
           await deleteUserAccount();
         }}
       >
@@ -166,4 +289,40 @@
   li {
     padding-top: 8px;
   }
+
+  input {
+    width: 100%;
+    grid-column: 1/-1;
+    grid-row: 1/2;
+    z-index: 1;
+  }
+
+  .input-wrapper {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #show-eye {
+    grid-column: 2/3;
+    grid-row: 1/2;
+    justify-self: end;
+    z-index: 2;
+    margin: 9px;
+    cursor: pointer;
+  }
+
+  .create-hide {
+    visibility: hidden;
+    height: 0;
+    opacity: 0;
+    padding: 0;
+  }
+
+  .create-show {
+    visibility: visible;
+    opacity: 1;
+    height: auto;
+    transition: opacity 1s linear, height 1s linear;
+  }
+
 </style>


### PR DESCRIPTION
Closes #453 

For email accounts, a password box is displayed, and reauthentication is handled the same way as for change email and change password.

For Google accounts, a popup is displayed. I wasn't able to easily get this working with redirects – I think that would require some additional routing work to intercept the redirect (when I tried off-the-bat, it would just take you back to account-settings page with all context lost). I figure it's ok to use popup for now given that a) it's MVP and we're moving to React soon and b) this is a rare flow.