### PR TITLE
add no-cache header to firebase.json to fix prod

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,10 @@
 {
   "hosting": {
     "public": "build",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "headers": [
+      { "source":"/service-worker.js", "headers": [{"key": "Cache-Control", "value": "no-cache"}] }
+    ]
   },
   "functions": {
     "source": "functions",


### PR DESCRIPTION
Jira: none

What this PR does:
* adds header for cache in firebase.json to break cache (so new deploys work) - see https://github.com/facebook/create-react-app/issues/2440#issuecomment-305592301
* fixes partial outage in prod that appears to be browser cache related