### PR TITLE
Fix email not verified

### DIFF
--- a/src/lib/components/auth-cards/LaunchCard.svelte
+++ b/src/lib/components/auth-cards/LaunchCard.svelte
@@ -21,8 +21,6 @@
 
   let customClass = "launch";
   let notVerified = false;
-  const notVerifiedText =
-    "Email account is not verified. Please check your inbox and activate your account.";
   let startState;
   let titleEl;
   let textWidth;
@@ -91,7 +89,11 @@
           class="card-button__img"
         />
         <p class="not-verified__text">
-          {notVerifiedText}
+          Email account is not verified. Please check your inbox and activate your account.
+          <br><br>
+          Can't find the email? <a href="#resend" on:click={() => {
+            store.resendUserVerificationEmail();
+          }}>Resend verification email</a>
         </p>
       </div>
     {/if}

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -345,13 +345,13 @@ export default {
         email,
         password
       );
+      console.info("Sending verification email");
+      await sendEmailVerification(userCredential.user);
     } catch (err) {
       console.error("there was an error", err);
       localStorage.setItem("createErr", err);
       return;
     }
-    console.info("Sending verification email");
-    await sendEmailVerification(userCredential.user);
   },
 
   async signOutUser() {

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -322,18 +322,16 @@ export default {
         throw new Error("google-only-account");
       }
       userCredential = await signInWithEmailAndPassword(auth, email, password);
+      if (userCredential.user.emailVerified) {
+        window.location.href = "/";
+      } else {
+        console.warn("Email account not verified");
+        localStorage.setItem("signInErr", "Email account not verified");
+      }
     } catch (err) {
       console.error("there was an error", err);
       localStorage.setItem("signInErr", err);
       return;
-    }
-    if (userCredential.user.emailVerified) {
-      window.location.href = "/";
-    } else {
-      console.warn("Email account not verified, sending verification email");
-      localStorage.setItem("signInErr", "Email account not verified");
-      await sendEmailVerification(userCredential.user);
-      await this.signOutUser();
     }
   },
 
@@ -451,7 +449,7 @@ export default {
       console.info("email verification resent!");
     } catch (err) {
       console.error("there was an error", err);
-      localStorage.setItem("changeEmailErr", err);
+      localStorage.setItem("authErr", err);
       return;
     }
   },


### PR DESCRIPTION
Closes #458 

This PR ensures that the "Email not verified" intervention shows up even if a user tries to sign in immediately after signing up (previously this would trigger a "too-many-requests" error because we were re-sending a verification email automatically and then signing out the user in quick succession). Instead, we now show a link that the user can click to trigger the resend, and we do not explicitly sign out the user.