### PR TITLE
add GA measurementID to stage,prod config to enable firebase analytics

### DIFF
--- a/config/firebase.config.rally-web-prod.json
+++ b/config/firebase.config.rally-web-prod.json
@@ -5,5 +5,6 @@
   "storageBucket": "moz-fx-data-rally-w-prod-dfa4.appspot.com",
   "messagingSenderId": "982322764946",
   "appId": "1:982322764946:web:f9b6aea488cebde47ada4b",
-  "functionsHost": "https://us-central1-moz-fx-data-rally-w-prod-dfa4.cloudfunctions.net"
+  "functionsHost": "https://us-central1-moz-fx-data-rally-w-prod-dfa4.cloudfunctions.net",
+  "measurementId": "G-39T53S2WCJ"
 }

--- a/config/firebase.config.rally-web-stage.json
+++ b/config/firebase.config.rally-web-stage.json
@@ -5,5 +5,6 @@
   "storageBucket": "moz-fx-data-rall-nonprod-ac2a.appspot.com",
   "messagingSenderId": "451372671583",
   "appId": "1:451372671583:web:eeb61e7d7c8ec898f5b1ea",
-  "functionsHost": "https://us-central1-moz-fx-data-rall-nonprod-ac2a.cloudfunctions.net"
+  "functionsHost": "https://us-central1-moz-fx-data-rall-nonprod-ac2a.cloudfunctions.net",
+  "measurementId": "G-LCB133PKPN"
 }


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/DSRE-747

What this PR does:
* adds measurementIds for Google Analytics to firebase stage & prod configs
* this sends data to 2 new Google Analytics properties in the `Mozilla (Apps + MP + more)` account under the Mozilla Corporation GA organization. javaun, jepstein & marnie have been made admins of both new GA properties (one for prod, one for stage).

Notes:
* This also requires an update to the monorepo as well with the same changes & caveats, since i'm uncertain which is now the actual repository deploying to production: 
* this PR __does not__ setup analytics initialization for the apps - i've included below the stock instructions on how to do so from the firebase analytics integration setup, but leave it to yall to review and decide how it fits in yall's app initialization setup

firebase stock initialization instructinos for stage (with firebase analytics enabled):
```
// Import the functions you need from the SDKs you need
import { initializeApp } from "firebase/app";
import { getAnalytics } from "firebase/analytics";
// TODO: Add SDKs for Firebase products that you want to use
// https://firebase.google.com/docs/web/setup#available-libraries

// Your web app's Firebase configuration
// For Firebase JS SDK v7.20.0 and later, measurementId is optional
const firebaseConfig = {
  apiKey: "AIzaSyAj3z6_cRdiBzwTuVzey6sJm0hVDVBSrDg",
  authDomain: "moz-fx-data-rall-nonprod-ac2a.firebaseapp.com",
  projectId: "moz-fx-data-rall-nonprod-ac2a",
  storageBucket: "moz-fx-data-rall-nonprod-ac2a.appspot.com",
  messagingSenderId: "451372671583",
  appId: "1:451372671583:web:eeb61e7d7c8ec898f5b1ea",
  measurementId: "G-LCB133PKPN"
};

// Initialize Firebase
const app = initializeApp(firebaseConfig);
const analytics = getAnalytics(app);
```

firebase stock initialization instructinos for prod (with firebase analytics enabled):
```
// Import the functions you need from the SDKs you need
import { initializeApp } from "firebase/app";
import { getAnalytics } from "firebase/analytics";
// TODO: Add SDKs for Firebase products that you want to use
// https://firebase.google.com/docs/web/setup#available-libraries

// Your web app's Firebase configuration
// For Firebase JS SDK v7.20.0 and later, measurementId is optional
const firebaseConfig = {
  apiKey: "AIzaSyAv_gSjNRMbEq3BFCNHPn0soXMCx2IxLeM",
  authDomain: "moz-fx-data-rally-w-prod-dfa4.firebaseapp.com",
  projectId: "moz-fx-data-rally-w-prod-dfa4",
  storageBucket: "moz-fx-data-rally-w-prod-dfa4.appspot.com",
  messagingSenderId: "982322764946",
  appId: "1:982322764946:web:f9b6aea488cebde47ada4b",
  measurementId: "G-39T53S2WCJ"
};

// Initialize Firebase
const app = initializeApp(firebaseConfig);
const analytics = getAnalytics(app);
```