### PR TITLE
Allow endDate to be a string that is not a parseable Date

### DIFF
--- a/src/lib/components/study-card/Header.svelte
+++ b/src/lib/components/study-card/Header.svelte
@@ -30,8 +30,11 @@
       by
       <slot name="study-author">author</slot>
       {#if endDate}
-        | Ends:
-        {niceDate(endDate)}
+        {#if !!Date.parse(endDate)}
+        | Ends: {niceDate(endDate)}
+        {:else}
+        | {endDate}
+        {/if}
       {/if}
     </div>
   </div>

--- a/src/lib/views/studies/Content.svelte
+++ b/src/lib/views/studies/Content.svelte
@@ -26,7 +26,8 @@
   function parseDateIfNeeded(date) {
     if (
       date === undefined ||
-      (typeof date === "object" && typeof date.getMonth === "function")
+      (typeof date === "object" && typeof date.getMonth === "function") ||
+      !Date.parse(date)
     )
       return date;
     try {


### PR DESCRIPTION
Fixes #584 

Code Review:
- needs only 1 approval
- just a sanity check to make sure I didn't break anything