### PR TITLE
Detect browser, link to correct store, and only show studies supported by current browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-typescript": "^7.17.12",
         "@mozilla-protocol/core": "^16.0.0",
-        "@mozilla/rally-functions": "^0.9.20",
+        "@mozilla/rally-functions": "^0.9.31",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/plugin-replace": "^4.0.0",
@@ -4256,9 +4256,9 @@
       }
     },
     "node_modules/@mozilla/rally-functions": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally-functions/-/rally-functions-0.9.20.tgz",
-      "integrity": "sha512-wuwZ8iz9Ux6pwn02Emusmzf/heAtzslMV5mqRsuyitMT+mIPFrpRRvFKaPpAoOe8z5Z9GFab1lIBaunAqN1pLA==",
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally-functions/-/rally-functions-0.9.31.tgz",
+      "integrity": "sha512-ZjmQ58U7DC/UnBh+Tce1YDo9RsRhzMUqN3y31HKODW1vToWl1vuf3K4+pGPghMFZU+BdVhH4JxqSyERkNs8Ulw==",
       "dev": true,
       "dependencies": {
         "@mozilla/glean": "^1.0.0",
@@ -48175,9 +48175,9 @@
       }
     },
     "@mozilla/rally-functions": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally-functions/-/rally-functions-0.9.20.tgz",
-      "integrity": "sha512-wuwZ8iz9Ux6pwn02Emusmzf/heAtzslMV5mqRsuyitMT+mIPFrpRRvFKaPpAoOe8z5Z9GFab1lIBaunAqN1pLA==",
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally-functions/-/rally-functions-0.9.31.tgz",
+      "integrity": "sha512-ZjmQ58U7DC/UnBh+Tce1YDo9RsRhzMUqN3y31HKODW1vToWl1vuf3K4+pGPghMFZU+BdVhH4JxqSyERkNs8Ulw==",
       "dev": true,
       "requires": {
         "@mozilla/glean": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.17.12",
     "@mozilla-protocol/core": "^16.0.0",
-    "@mozilla/rally-functions": "^0.9.20",
+    "@mozilla/rally-functions": "^0.9.31",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-replace": "^4.0.0",

--- a/src/lib/components/study-card/StudyStatusBadge.svelte
+++ b/src/lib/components/study-card/StudyStatusBadge.svelte
@@ -21,9 +21,13 @@
     <span class="text-body-sm not-connected title"
       >You're not participating yet.
       {#if !connected}
-        <a href={downloadUrl} target="_blank"
-          >Add this study extension from the Chrome store.</a
-        >
+        <a href={downloadUrl} target="_blank">
+          {#if window.navigator.userAgent.includes("Firefox")}
+            Add this study extension from the Firefox store.
+          {:else}
+            Add this study extension from the Chrome store.
+          {/if}
+        </a>
       {/if}
     </span>
   {/if}

--- a/src/lib/stores/types.ts
+++ b/src/lib/stores/types.ts
@@ -60,7 +60,10 @@ export interface StudyMetadata {
   version: string;
   studyEnded: boolean;
   studyPaused: boolean;
-  downloadLink: string;
+  downloadLink: {
+    chrome: string;
+    firefox: string;
+  };
   schemaNamespace?: string;
   studyDetailsLink: string;
   minimumCoreVersion?: string;

--- a/src/lib/stores/types.ts
+++ b/src/lib/stores/types.ts
@@ -61,8 +61,8 @@ export interface StudyMetadata {
   studyEnded: boolean;
   studyPaused: boolean;
   downloadLink: {
-    chrome: string;
-    firefox: string;
+    chrome?: string;
+    firefox?: string;
   };
   schemaNamespace?: string;
   studyDetailsLink: string;

--- a/src/lib/views/studies/Content.svelte
+++ b/src/lib/views/studies/Content.svelte
@@ -42,7 +42,13 @@
     }
   }
 
-  $: currentStudies = studies.filter((s) => !s.studyEnded && !s.studyPaused);
+  $: currentStudies = studies.filter((s) => {
+    const UA = window.navigator.userAgent;
+    const browserCompat =
+      (UA.includes("Firefox") && s.downloadLink.firefox) ||
+      (UA.includes("Chrome") && s.downloadLink.chrome);
+    return !s.studyEnded && !s.studyPaused && browserCompat;
+  });
 </script>
 
 <div class="current-studies" in:fly={{ duration: 800, y: 5 }}>

--- a/src/lib/views/studies/Content.svelte
+++ b/src/lib/views/studies/Content.svelte
@@ -42,7 +42,7 @@
     }
   }
 
-  $: currentStudies = studies.filter(s => !s.studyEnded && !s.studyPaused);
+  $: currentStudies = studies.filter((s) => !s.studyEnded && !s.studyPaused);
 </script>
 
 <div class="current-studies" in:fly={{ duration: 800, y: 5 }}>
@@ -72,7 +72,9 @@
         dataCollectionDetails={study.dataCollectionDetails}
         studyDetailsLink={study.studyDetailsLink}
         tags={study.tags}
-        downloadUrl={study.downloadLink}
+        downloadUrl={window.navigator.userAgent.includes("Firefox")
+          ? study.downloadLink.firefox
+          : study.downloadLink.chrome}
         on:cta-clicked
         on:join={() => {
           joinStudy(study.studyId);

--- a/src/lib/views/studies/StudyCardContainer.svelte
+++ b/src/lib/views/studies/StudyCardContainer.svelte
@@ -55,10 +55,13 @@
   let analytics;
   let logEvent;
   let mounted = false;
+  let UA;
   onMount(async () => {
     Dialog = (await import("$lib/components/Dialog.svelte")).default;
     analytics = (await import("firebase/analytics")).getAnalytics();
     logEvent = (await import("firebase/analytics")).logEvent;
+
+    UA = window.navigator.userAgent;
 
     mounted = true;
   });
@@ -97,7 +100,8 @@
 
     <div slot="body" class="dialog-body">
       You previously started to join this study, but didn’t finish the process
-      by installing the study extension from the Chrome Web Store.
+      by installing the study extension from the {#if UA.includes("Firefox")}Firefox
+        Add-ons Store{:else}Chrome Web Store{/if}.
     </div>
 
     <div class="modal-call-flow" slot="cta">

--- a/src/lib/views/studies/StudyUsageTooltip.svelte
+++ b/src/lib/views/studies/StudyUsageTooltip.svelte
@@ -1,6 +1,7 @@
 <script>
   let clazz;
   export { clazz as class };
+  let UA = window.navigator.userAgent;
 </script>
 
 <ol class={`container ${clazz || ""}`}>
@@ -8,24 +9,29 @@
     <h1>Read the study card</h1>
     <p>
       The card discloses the data we collect from you, who has access to the
-      data, and how it will be used. 
+      data, and how it will be used.
     </p>
   </li>
 
   <li>
     <h1>Join the Study</h1>
     <p>
-      Click the <b>Join Study</b> button. We'll ask you to confirm in a pop-up dialog
-      by clicking the <b>Add Study Extension</b> button. This will open up the Chrome
-      Web Store.
+      Click the <b>Join Study</b> button. We'll ask you to confirm in a pop-up
+      dialog by clicking the <b>Add Study Extension</b> button. This will open
+      up the {#if UA.includes("Firefox")}Firefox Add-ons Store{:else}Chrome Web
+        Store{/if}.
     </p>
   </li>
 
   <li>
     <h1>Add study extension</h1>
     <p>
-      In the Chrome Web Store, click on the <b>Add to Chrome</b> button. This will
-      add the study's extension to your browser. You are now participating!
+      In the {#if UA.includes("Firefox")}Firefox Add-ons Store{:else}Chrome Web
+        Store{/if}, click on the
+      <b
+        >{#if UA.includes("Firefox")}Add To Firefox{:else}Add to Chrome{/if}</b
+      > button. This will add the study's extension to your browser. You are now
+      participating!
     </p>
   </li>
 </ol>

--- a/src/routes/studies/index.svelte
+++ b/src/routes/studies/index.svelte
@@ -25,7 +25,10 @@
     }
 
     if (!$installedStudyIds.includes(studyId)) {
-      window.open(study.downloadLink, "_blank");
+      let downloadLink = window.navigator.userAgent.includes("Firefox")
+        ? study.downloadLink.firefox
+        : study.downloadLink.chrome;
+      window.open(downloadLink, "_blank");
     }
 
     store.updateStudyEnrollment(studyId, true);

--- a/tests/integration/extension/src/background.ts
+++ b/tests/integration/extension/src/background.ts
@@ -2,7 +2,7 @@ import { Rally, RunStates } from "@mozilla/rally-sdk";
 
 const enableDevMode = false;
 const rallySite = "http://localhost:5000";
-const studyId = "facebookPixelHunt";
+const studyId = "attentionStream";
 
 // TODO load from JSON file in /config/
 const firebaseConfig = {


### PR DESCRIPTION
Closes #587

- detects browser via UserAgent
- uses appropriate store link
- changes copy to reflect which browser you are using
- **only shows studies supported by the current browser**

Reviewer:
- Check out locally and do a functionality sanity check
- Verify that hiding studies not supported by the browser is ok behavior (change from previous, e.g. Safari users no longer see any studies)