### PR TITLE
Redirect with query params

### DIFF
--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -152,6 +152,8 @@ export default {
       analytics = (await import("firebase/analytics")).getAnalytics();
       logEvent = (await import("firebase/analytics")).logEvent;
 
+      logEvent(analytics, "page_view");
+
       const handleContentScriptEvents = async (
         /** @type {CustomEvent} */ e
       ) => {

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -152,8 +152,6 @@ export default {
       analytics = (await import("firebase/analytics")).getAnalytics();
       logEvent = (await import("firebase/analytics")).logEvent;
 
-      logEvent(analytics, "page_view");
-
       const handleContentScriptEvents = async (
         /** @type {CustomEvent} */ e
       ) => {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getContext, onMount } from "svelte";
   import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
 
   import type { Readable } from "svelte/store";
   import type { AppStore } from "$lib/stores/types";
@@ -11,38 +12,21 @@
   );
 
   onMount(async () => {
-    const getApps = (await import("firebase/app")).getApps;
-    const analytics = (await import("firebase/analytics")).getAnalytics();
-    const logEvent = (await import("firebase/analytics")).logEvent;
-
-    if (getApps().length === 0) {
-      const initializeApp = (await import("firebase/app")).initializeApp;
-      const request = await fetch("/firebase.config.json");
-      const firebaseConfig = await request.json();
-
-      initializeApp(firebaseConfig);
-    }
-
-    // Ensure page_view is logged for index page
-    // in order to capture attribution codes
-    logEvent(analytics, "page_view");
-
     isAuthenticated.subscribe((state) => {
       if (state === false) {
-        goto("/signup");
         localStorage.removeItem("isLoading");
+        goto(`/signup?${$page.query.toString()}`);
       }
     });
-  })
+  });
 
   $: if ($isAuthenticated !== undefined && $store._initialized) {
-    if (!$store?.user?.uid) {
-      goto("/signup");
-      localStorage.removeItem("isLoading");
-    } else if (!$store?.user?.enrolled) {
-      goto("/welcome/terms");
-    }else{
-      goto ("/studies")
+    if ($store?.user?.uid) {
+      if (!$store?.user?.enrolled) {
+        goto(`/welcome/terms?${$page.query.toString()}`);
+      } else {
+        goto(`/studies?${$page.query.toString()}`);
+      }
     }
   }
 </script>

--- a/src/routes/signup/index.svelte
+++ b/src/routes/signup/index.svelte
@@ -44,12 +44,12 @@
   } = state.card;
 
   $: if ($store._initialized) {
-    if (!$store?.user?.uid) {
-      goto("/signup");
-    } else if (!$store?.user?.enrolled) {
-      goto("/welcome/terms");
-    } else {
-      goto("/studies");
+    if ($store?.user?.uid) {
+      if (!$store?.user?.enrolled) {
+        goto("/welcome/terms");
+      } else {
+        goto("/studies");
+      }
     }
   }
 
@@ -133,10 +133,12 @@
 <div class={isCreateAccountShown ? "sign-in-background" : ""}>
   <section class="signin md-container-signin">
     <h2 class="mzp-c-call-out-title mzp-has-zap-1 signin__logo">
-      <a class="external-link rwp-link"
+      <a
+        class="external-link rwp-link"
         target="_blank"
         rel="noopener noreferrer"
-        href="__BASE_SITE__/how-rally-works/">
+        href="__BASE_SITE__/how-rally-works/"
+      >
         <img src="img/logo-wide.svg" alt="Mozilla Rally Logo" />
       </a>
     </h2>
@@ -171,15 +173,9 @@
               <div class="launch-card-text">
                 <h5>Use your data to build a better internet</h5>
                 <ul>
-                  <li>
-                    Monitor big tech platforms
-                  </li>
-                  <li>
-                    Improve user privacy and control
-                  </li>
-                  <li>
-                    Leave at any time. We'll delete your data
-                  </li>
+                  <li>Monitor big tech platforms</li>
+                  <li>Improve user privacy and control</li>
+                  <li>Leave at any time. We'll delete your data</li>
                 </ul>
               </div>
             {/if}
@@ -226,6 +222,7 @@
     </div>
   </section>
 </div>
+
 <style>
   .spinner-wrapper {
     text-align: center;
@@ -235,7 +232,7 @@
     width: 100%;
     height: 100vh;
     background: no-repeat;
-    background-image: url('/img/network-background.png');
+    background-image: url("/img/network-background.png");
     background-position: right top;
   }
 
@@ -255,7 +252,7 @@
 
   .launch-card-container .launch-card-text ul li {
     background: no-repeat;
-    background-image: url('/img/checkmark-static.png');
+    background-image: url("/img/checkmark-static.png");
     line-height: 35px;
     padding-left: 40px;
     white-space: nowrap;


### PR DESCRIPTION
Instead of initializing Firebae in the router for `/`, preserve the query params in redirects and let the new page handle it. We seem to be getting `page_view` "for free" so I'm not sure we need to explicitly send it.