### PR TITLE
fix #619, only send activate_extension GA event on complete-signup

### DIFF
--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -209,11 +209,13 @@ export default {
             );
 
             const eventParams = { studyId };
-            ["source", "medium", "campaign", "term", "content"].forEach(code => {
-              if (code in attribution) {
-                eventParams[code] = attribution[code];
-              }
-            });
+            if (attribution) {
+              ["source", "medium", "campaign", "term", "content"].forEach(code => {
+                if (code in attribution) {
+                  eventParams[code] = attribution[code];
+                }
+              });
+            }
 
             logEvent(analytics, "activate_extension", eventParams);
 

--- a/src/lib/stores/api.js
+++ b/src/lib/stores/api.js
@@ -82,16 +82,7 @@ async function getStudies() {
 }
 
 const _stateChangeCallbacks = [];
-const _connectedChangeCallbacks = [async (/** @type {string} */ studyId, /** @type {{ [utmCode: string]: string; }} */ attribution) => {
-  // TODO figure out how to send attribution in a way FA will use it automatically.
-  const eventParams = { studyId };
-  ["source", "medium", "campaign", "term", "content"].forEach(code => {
-    if (code in attribution) {
-      eventParams[code] = attribution[code];
-    }
-  })
-  logEvent(analytics, "activate_extension", eventParams);
-}];
+const _connectedChangeCallbacks = [];
 
 const _authChangeCallbacks = [async (/** @type {import("firebase/auth").User} */ user) => {
   const loggedIn = Boolean(user && user.uid);
@@ -159,6 +150,7 @@ export default {
           case "rally-sdk.complete-signup": {
             const detail = JSON.parse(e.detail);
             const studyId = detail && detail.studyId;
+            const attribution = detail && detail.attribution;
 
             if (!studyId) {
               throw new Error(
@@ -215,13 +207,22 @@ export default {
                 detail: { studyId, rallyToken },
               })
             );
+
+            const eventParams = { studyId };
+            ["source", "medium", "campaign", "term", "content"].forEach(code => {
+              if (code in attribution) {
+                eventParams[code] = attribution[code];
+              }
+            });
+
+            logEvent(analytics, "activate_extension", eventParams);
+
             break;
           }
           case "rally-sdk.web-check-response": {
             console.debug("Received rally-sdk.web-check-response.");
             const detail = JSON.parse(e.detail);
             const studyId = detail && detail.studyId;
-            const attribution = detail && detail.attribution;
 
             if (!studyId) {
               throw new Error(
@@ -238,7 +239,7 @@ export default {
                   `Received rally-sdk.web-check-response for non-existent study: ${studyId}`
                 );
               }
-              callback(studyId, attribution);
+              callback(studyId);
             });
             break;
           }


### PR DESCRIPTION
Just a visual check is OK, I'd like to test this on stage before we deploy.